### PR TITLE
Minor playbook fixes

### DIFF
--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -8,7 +8,6 @@
 
 
 # Testing vars. Set:
-# - `idr_nginx_ssl_production=False` to generate a self-signed https cert
 # - `idr_net_iface=iface` if your servers use a network interface other
 #   then eth0 for inter-machine networking
 

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -38,12 +38,14 @@
     when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] is defined }}"
 
   roles:
-  # Default to a self-signed certificate, set `idr_nginx_ssl_production: True`
-  # to use production certificates
+  # Default to a self-signed certificate, to use production certificates set:
+  # idr_nginx_ssl_production: True
+  # nginx_proxy_ssl_certificate_source_path: local/path/to/certificate
+  # nginx_proxy_ssl_certificate_key_source_path: local/path/to/key
   - role: openmicroscopy.nginx-ssl-selfsigned
     nginx_ssl_certificate: "{{ nginx_proxy_ssl_certificate }}"
     nginx_ssl_certificate_key: "{{ nginx_proxy_ssl_certificate_key }}"
-    when: "{{ not idr_nginx_ssl_production | default(True) | bool }}"
+    when: "{{ not idr_nginx_ssl_production | default(False) | bool }}"
   - role: openmicroscopy.nginx-proxy
 
 

--- a/ansible/molecule.yml
+++ b/ansible/molecule.yml
@@ -4,7 +4,7 @@ dependency:
   requirements_file: requirements.yml
 
 driver:
-    name: docker
+  name: docker
 #  name: vagrant
 #  name: openstack
 
@@ -145,17 +145,13 @@ ansible:
 
     vagrant-hosts:
     # Vagrant attaches the private network to eth1
-    - idr_net_iface: eth1
-
-    proxy-hosts:
-    # Create a self-signed HTTPS SSL certificate
-    - idr_nginx_ssl_production: False
+      idr_net_iface: eth1
 
 
   host_vars:
 
     idr-omero-docker:
-    - omero_server_systemd_require_network: False
+      omero_server_systemd_require_network: False
 
 
 verifier:

--- a/ansible/openstack-create-infrastructure.yml
+++ b/ansible/openstack-create-infrastructure.yml
@@ -2,17 +2,18 @@
 - hosts: localhost
   connection: local
 
-  # These variables should be defined in a variables file and included
+  # These variables can be defined in a variables file and included
   # on the ansible command line as -e @path/to/secret.yml
   vars:
+    # Do not change these unless you are running multiple deployments
     - idr_deployment_cloud: idr
     - idr_environment_idr: idr
     # Analysis instances must have `-a` as the suffix so that the single
     # gateway VM can proxy it
     - idr_environment_analysis: "{{ idr_environment_idr }}-a"
-    # Required: List of public SSH keys
+    # REQUIRED: List of public SSH keys
     - idr_keypair_keys:
-
+    # Change these to match the image and flavours in your OpenStack cloud
     - vm_image: CentOS 7
     - vm_flavour: m1.large
     - vm_flavour_large: m1.xlarge
@@ -20,6 +21,7 @@
 
     # Copy these volumes for the production IDR
     # The analysis instances will be copied from the current production
+    # The default is to initialise new volumes
     - idr_volume_database_db_src: "{{ omit }}"
     - idr_volume_omero_data_src: "{{ omit }}"
     - idr_volume_proxy_nginxcache_src: "{{ omit }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -35,6 +35,9 @@
 - src: openmicroscopy.logrotate
   version: 1.0.0
 
+- src: openmicroscopy.lvm-partition
+  version: 1.0.0
+
 - src: openmicroscopy.munin
   version: 1.1.3-openmicroscopy1
 


### PR DESCRIPTION
Some minor fixes discovered whilst writing the standalone deployment docs. The most significant change is defaulting to Nginx self-signed SSL certificates- without this Nginx will fail to start due to missing certificates. This won't affect production deployments because they define `idr_nginx_ssl_production: True`