### PR TITLE
Travis test idr-01-install-idr.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ install:
   - pip install -r ansible/tests/python-requirements.txt
 
 script:
+  # TODO: molecule will only run ansible-lint on the target playbook,
+  # we should run it on all once they're compliant
+  - bash -O extglob -c 'ansible-lint -v ansible/!(idr-03-postinstall.yml|idr-reset-users-groups.yml|molecule.yml|ansible.cfg)'
   - cd ansible; molecule test
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ script:
   # we should run it on all once they're compliant
   - bash -O extglob -c 'ansible-lint -v ansible/!(idr-03-postinstall.yml|idr-reset-users-groups.yml|molecule.yml|ansible.cfg)'
   - cd ansible; molecule test
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+language: python
+
+services:
+  - docker
+
+install:
+  - pip install -r ansible/tests/python-requirements.txt
+
+script:
+  - cd ansible; molecule test
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -78,7 +78,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.postgresql
-  version: 1.0.0
+  version: 2.0.0
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -110,7 +110,7 @@
 
 - name: IDR.openstack-idr-instance
   src: https://github.com/IDR/ansible-role-openstack-idr-instance.git
-  version: 1.0.1
+  version: 1.0.2
 
 - name: IDR.openstack-idr-instance-network
   src: https://github.com/IDR/ansible-role-openstack-idr-instance-network.git
@@ -122,7 +122,7 @@
 
 - name: IDR.openstack-idr-network
   src: https://github.com/IDR/ansible-role-openstack-idr-network.git
-  version: 2.0.0
+  version: 2.0.1
 
 - name: IDR.openstack-idr-security-groups
   src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git

--- a/ansible/tests/python-requirements.txt
+++ b/ansible/tests/python-requirements.txt
@@ -1,0 +1,3 @@
+docker-py
+ansible<2.2
+molecule==1.20


### PR DESCRIPTION
Bump requirements.
Test `idr-01-install-idr.yml` applied to `idr-database`, `idr-omero`, `idr-proxy` with travis in Docker. The other main deployment playbooks and servers (such as the analysis servers) aren't tested. This corresponds to the main public production IDR.