### PR TITLE
0.3.4: Add mineotaur, rsync support, etc

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -7,7 +7,7 @@ omero_system_uid: 546
 
 omero_web_runtime_redis: True
 # This refers to a custom IDR release URL, not an official OMERO version
-omero_release: "0.3.3"
+omero_release: "0.3.4"
 ice_version: "3.6"
 omero_omego_additional_args: "--downloadurl https://downloads.openmicroscopy.org/idr"
 # Upgrades are normally disabled, uncomment if you want to upgrade OMERO:

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -212,6 +212,14 @@ nginx_proxy_direct_locations:
 
 #nginx_proxy_set_header_host: 'idr-demo.openmicroscopy.org'
 
+# List of backend streaming servers
+nginx_proxy_streams:
+- name: idrrsync
+  port: 873
+  servers:
+  - "{{ omero_omero_host_ansible }}:873 max_fails=3 fail_timeout=30s"
+  connect_timeout: "1s"
+  timeout: "3s"
 
 ######################################################################
 # Static webpages (/about) on proxy

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -57,10 +57,24 @@ _nginx_proxy_backends_jupyter:
   # `location` scope when websockets are used
   host_header: "$host"
 
+# omero_mineotaur_host_ansible may be empty
+_nginx_proxy_backends_mineotaur:
+- name: mineotaur
+  location: "^~ /mineotaur"
+  server: "http://{{ omero_mineotaur_host_ansible | default(None) }}"
+  read_timeout: 86400
+  # `proxy_set_header Host $host` is already set in the parent `server` scope,
+  # but there seems to be a issue which means it also needs to be set at the
+  # `location` scope when websockets are used
+  host_header: "$host"
+
 nginx_proxy_backends: >
   {{ _nginx_proxy_backends_omero +
      ((omero_jupyter_host_ansible is defined) |
        ternary(_nginx_proxy_backends_jupyter, [])
+     ) +
+     ((omero_mineotaur_host_ansible is defined) |
+       ternary(_nginx_proxy_backends_mineotaur, [])
      ) }}
 
 

--- a/ansible/idr-downloads.yml
+++ b/ansible/idr-downloads.yml
@@ -19,6 +19,9 @@
     - name: sql
       path: /srv/omero-sql
       comment: PostgreSQL 9.4 database dump of the IDR
+    - name: mineotaur
+      path: /data/mineotaur
+      comment: Neo4j databases for various IDR studies
 
   # TODO: Create DB dump file? Or should this be in another playbooks since
   # it's not directly related to deployment?

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -49,6 +49,14 @@
         }}:8080
     when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] is defined }}"
 
+  - name: Configure rsync port in selinux
+    become: yes
+    seport:
+      ports: 873
+      proto: tcp
+      setype: http_port_t
+      state: present
+
   roles:
   # Default to a self-signed certificate, to use production certificates set:
   # idr_nginx_ssl_production: True

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -37,6 +37,18 @@
         }}:8000
     when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] is defined }}"
 
+  - name: Get mineotaur IP
+    set_fact:
+      # Optional, so that it can run in an environment where there's only
+      # an OMERO server but no analysis platform
+      omero_mineotaur_host_ansible: >-
+        {{
+          hostvars[groups[
+            idr_environment | default('idr') + '-a-dockermanager-hosts'][0]]
+            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+        }}:8080
+    when: "{{ groups[idr_environment | default('idr') + '-a-dockermanager-hosts'] is defined }}"
+
   roles:
   # Default to a self-signed certificate, to use production certificates set:
   # idr_nginx_ssl_production: True

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -126,7 +126,7 @@
 
 - name: IDR.openstack-idr-security-groups
   src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git
-  version: 1.0.0
+  version: 1.1.0
 
 # External development roles
 - name: omero-user


### PR DESCRIPTION
 * Similar to the forwarding of `/jupyter` to a container on the dockermanager host, this forwards `/mineotaur` to another container on port 8080.
 * Permit rsync'ing from /data/OMERO/mineotaur on the omero host
 * Open rsync on the proxy host