### PR TITLE
mineotaur: enable deployment (IDR-0.3.6)

### DIFF
--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -8,7 +8,7 @@
 
 - include: idr-docker.yml
 
-#- include: idr-mineotaur.yml
+- include: idr-mineotaur.yml
 
 - include: idr-downloads.yml
 

--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -8,8 +8,6 @@
 
 - include: idr-docker.yml
 
-- include: idr-mineotaur.yml
-
 - include: idr-downloads.yml
 
 - include: idr-proxy.yml

--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -1,0 +1,3 @@
+# Runs all playbooks for setting up services built on top of the IDR
+
+- include: idr-mineotaur.yml

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -1,28 +1,45 @@
+# Load hostvars
+- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+
 # Setup IDR Mineotaur server
 - hosts: "{{ idr_environment | default('idr') }}-a-dockermanager-hosts"
 
   tasks:
 
+  - name: Get rsync IP
+    set_fact:
+      omero_rsync_host_ansible : >-
+        {{
+          hostvars[groups[
+            idr_environment | default('idr') + '-omero-hosts'][0]]
+            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+        }}
+
   - name: download mineotaur data
     become: yes
     synchronize:
-      src: "rsync://{{ TBD_omero_host }}/mineotaur/"
+      src: "rsync://idr-demo.openmicroscopy.org/mineotaur/"
       dest: "/tmp/mineotaur/"
+      mode: "pull"
+    delegate_to: "{{ inventory_hostname }}"
+    # TODO: "rsync://{{ omero_rsync_host_ansible }}/mineotaur/" currently inaccessible due to networking
 
   - name: change mineotaur to 1000 uid
     become: yes
     file:
       path: "/tmp/mineotaur"
       owner: 1000
+      recurse: yes
 
   # TODO: add version
   - name: enable mineotaur container
+    become: yes
     docker_container:
       name: mineotaur
       image: imagedata/mineotaur
       entrypoint: java
       volumes:
-        - /tmp/mineotaur:/mineotaur
+        - /tmp/mineotaur/idr0001gramlsysgroscreenA:/mineotaur
       ports:
         - "8080:8080"
-      command: ["-Xmx8g", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/home/build/src/target/Mineotaur-1.0.1.jar", "-start", "/mineotaur"]
+      command: "-Xmx8g -Djava.security.egd=file:/dev/./urandom -jar /home/build/src/target/Mineotaur-1.0.1.jar -start /mineotaur"

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -27,7 +27,7 @@
   - name: change mineotaur to 1000 uid
     become: yes
     file:
-      path: "/tmp/mineotaur"
+      path: "/data/mineotaur"
       owner: 1000
       recurse: yes
 
@@ -39,7 +39,7 @@
       image: imagedata/mineotaur
       entrypoint: java
       volumes:
-        - /tmp/mineotaur/idr0001gramlsysgroscreenA:/mineotaur
+        - /data/mineotaur/idr0001gramlsysgroscreenA:/mineotaur
       ports:
         - "8080:8080"
       command: "-Xmx8g -Djava.security.egd=file:/dev/./urandom -jar /home/build/src/target/Mineotaur-1.0.1.jar -start /mineotaur"

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -15,21 +15,25 @@
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
 
-  - name: download mineotaur data
-    become: yes
-    synchronize:
-      src: "rsync://idr-demo.openmicroscopy.org/mineotaur/"
-      dest: "/tmp/mineotaur/"
-      mode: "pull"
-    delegate_to: "{{ inventory_hostname }}"
-    # TODO: "rsync://{{ omero_rsync_host_ansible }}/mineotaur/" currently inaccessible due to networking
-
-  - name: change mineotaur to 1000 uid
+  - name: create mineotaur directory
     become: yes
     file:
       path: "/data/mineotaur"
       owner: 1000
-      recurse: yes
+      state: directory
+
+  # Run as UID 1000 since this is required by the Docker container
+  - name: download mineotaur data
+    become: yes
+    become_user: 1000
+    synchronize:
+      src: "rsync://idr-demo.openmicroscopy.org/mineotaur/"
+      dest: "/data/mineotaur/"
+      mode: "pull"
+      owner: no
+      group: no
+    delegate_to: "{{ inventory_hostname }}"
+    # TODO: "rsync://{{ omero_rsync_host_ansible }}/mineotaur/" currently inaccessible due to networking
 
   # TODO: add version
   - name: enable mineotaur container
@@ -37,6 +41,7 @@
     docker_container:
       name: mineotaur
       image: imagedata/mineotaur
+      user: 1000
       entrypoint: java
       volumes:
         - /data/mineotaur/idr0001gramlsysgroscreenA:/mineotaur

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -42,4 +42,4 @@
         - /data/mineotaur/idr0001gramlsysgroscreenA:/mineotaur
       ports:
         - "8080:8080"
-      command: "-Xmx8g -Djava.security.egd=file:/dev/./urandom -jar /home/build/src/target/Mineotaur-1.0.1.jar -start /mineotaur"
+      command: "-Xmx8g -Djava.security.egd=file:/dev/urandom -jar /home/build/src/target/Mineotaur-1.0.1.jar -start /mineotaur"


### PR DESCRIPTION
 * rsync from the production
 * initial work for rsync'ing from `omero_omero` host
 * use the hard-coded sysgro subdir