### PR TITLE
rsync: update script to match new deployment

### DIFF
--- a/ansible/files/idr-rsync-backup.sh
+++ b/ansible/files/idr-rsync-backup.sh
@@ -3,14 +3,14 @@
 set -e
 set -u
 
-HOST=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.host")
-PASS=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.pass")
+PGHOST=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.host")
+PGPASSWORD=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.pass")
 DATE=$(date +"%Y-%m-%d")
 test -e $DATE && {
   echo $DATE already exists
   exit 1
 }
-time pg_dump -h $HOST -U omero idr -j 8 -Fd -f $DATE \
+time pg_dump -U omero idr -j 8 -Fd -f $DATE \
     --exclude-table-data password \
     --exclude-table-data eventlog
 chmod -R a+rX $DATE

--- a/ansible/files/idr-rsync-backup.sh
+++ b/ansible/files/idr-rsync-backup.sh
@@ -3,8 +3,8 @@
 set -e
 set -u
 
-HOST=$(su omero -lc "omero config get omero.db.host")
-echo $HOST
+HOST=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.host")
+PASS=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.pass")
 DATE=$(date +"%Y-%m-%d")
 test -e $DATE && {
   echo $DATE already exists


### PR DESCRIPTION
`bin/omero` no longer looks to be on the user's
PATH. This uses the absolute paths.