### PR TITLE
Fix uod nfs mount

### DIFF
--- a/ansible/idr-dundee-nfs.yml
+++ b/ansible/idr-dundee-nfs.yml
@@ -27,5 +27,5 @@
       fstype: nfs4
       name: "{{ idr_mountpoint }}"
       opts: ro
-      src: idr-data.openmicroscopy.org:/idr
+      src: idr-data.openmicroscopy.org:/uod/idr
       state: mounted


### PR DESCRIPTION
The NFS mount should be `/uod/idr`

In the future the `idr-*-nfs.yml` playbooks should be refactored into a single playbook, with variables in group-vars.