### PR TITLE
Run JupyterHub 0.7.2 directly

### DIFF
--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
-idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
-idr_jupyter_notebook_image: "imagedata/jupyter-docker:0.2.0"
+#idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
+idr_jupyter_notebook_image: "manics/jupyter-docker:merge"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
 idr_jupyter_notebook_repo_version: "0.4.0"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
 #idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
-idr_jupyter_notebook_image: "manics/jupyter-docker:merge"
+idr_jupyter_notebook_image: "imagedata/jupyter-docker:0.3.0"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
 idr_jupyter_notebook_repo_version: "0.4.0"

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -50,7 +50,7 @@ _nginx_proxy_backends_omero:
 # omero_jupyter_host_ansible may be empty
 _nginx_proxy_backends_jupyter:
 - name: jupyter
-  location: "^~ /jupyter"
+  location: "^~ /jupyter/"
   server: "http://{{ omero_jupyter_host_ansible | default(None) }}"
   websockets: True
   read_timeout: 86400

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -118,8 +118,8 @@
   version: 1.0.0
 
 - name: IDR.idr-jupyter
-  src: https://github.com/IDR/ansible-role-idr-jupyter.git
-  version: 1.1.0
+  src: https://github.com/manics/ansible-role-idr-jupyter.git
+  version: run-direct-0.7.2
 
 - name: IDR.openstack-idr-instance
   src: https://github.com/IDR/ansible-role-openstack-idr-instance.git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -118,8 +118,8 @@
   version: 1.0.0
 
 - name: IDR.idr-jupyter
-  src: https://github.com/manics/ansible-role-idr-jupyter.git
-  version: run-direct-0.7.2
+  src: https://github.com/IDR/ansible-role-idr-jupyter.git
+  version: 2.0.0
 
 - name: IDR.openstack-idr-instance
   src: https://github.com/IDR/ansible-role-openstack-idr-instance.git


### PR DESCRIPTION
- [x] --depends-on https://github.com/IDR/jupyter-docker/pull/7
- [x] --depends-on https://github.com/IDR/ansible-role-idr-jupyter/pull/3

See:
- https://trello.com/c/QPUQBShK/23-github-org-oauth-seems-to-let-everyone-in
- https://trello.com/c/0SacUNN6/24-update-all-jupyterhub-components