### PR TITLE
Set omero.web.wsgi_workers: 25 (IDR-0.3.7)

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -76,6 +76,7 @@ omero_web_config_set:
   # web
   omero.web.application_server: wsgi-tcp
   omero.web.application_server.max_requests: 300
+  omero.web.wsgi_workers: 25
   #omero.web.wsgi_timeout 30
   #omero.web.wsgi_args -- '--forwarded-allow-ips=YOUR_IP'
   omero.web.use_x_forwarded_host: True


### PR DESCRIPTION
See https://trello.com/c/s22IQBKY/26-increase-gunicorn-workers

OMERO.web and OMERO.server are currently on the same VM. In the event this change to the number of wsgi-workers causes problems revert it.