### PR TITLE
Openstack snapshot and delete scripts (IDR-0.4.0)

### DIFF
--- a/scripts/os-idr-delete.sh
+++ b/scripts/os-idr-delete.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Run this script to get a list of commands to delete all potential resources
+# If you want to run it directly (not recommended):
+#     bash <(./os-idr-delete.sh IDR_ENVIRONMENT)
+
+set -eu
+
+idr_environment=$1
+for server in proxy omero database management; do
+    echo openstack server delete ${idr_environment}-${server}
+done
+echo
+
+for server in omero database dockermanager dockerworker; do
+    echo openstack server delete ${idr_environment}-a-${server}
+done
+echo
+
+for volume in proxy-nginxcache omero-data database-db; do
+    echo openstack volume delete ${idr_environment}-${volume}
+done
+echo
+
+for volume in omero-data database-db dockermanager-data; do
+    echo openstack volume delete ${idr_environment}-a-${volume}
+done
+echo
+
+for router in ${idr_environment}-router ${idr_environment}-a-router; do
+    echo "for port in \$(openstack port list --router ${router} -f value | cut -d\  -f1); do"
+    echo "    openstack router remove port ${router} \$port"
+    echo "done"
+    echo
+done
+echo
+
+for router in ${idr_environment}-router ${idr_environment}-a-router; do
+    echo openstack router delete ${router}
+done
+echo
+
+for network in ${idr_environment} ${idr_environment}-a; do
+    echo openstack network delete ${network}
+done
+echo
+
+echo openstack server list -f yaml
+echo openstack volume list -f yaml
+echo openstack network list -f yaml
+echo openstack router list -f yaml

--- a/scripts/os-idr-snapshot.sh
+++ b/scripts/os-idr-snapshot.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Snapshot IDR OpenStack volumes and instances
+
+# Attempt to continue on error
+#set -e
+set -u
+
+if [ $# -ne 1 ]; then
+    echo "USAGE: $(basename "$0") vm_prefix"
+    exit 1
+fi
+
+vm_prefix="$1"
+today=$(date +%Y%m%d)
+vm_errors=0
+vol_errors=0
+
+for vm in \
+        database \
+        omero \
+        proxy \
+        a-dockermanager \
+        management \
+        ; do
+    server="$vm_prefix-$vm"
+    echo "Snapshotting server $server"
+    openstack server image create --name "$server-$today" "$server" -f yaml
+    [ $? -eq 0 ] || let vm_errors++
+    echo
+done
+
+for vol in \
+        database-db \
+        omero-data \
+        proxy-nginxcache \
+        a-dockermanager-data \
+        ; do
+    volume="$vm_prefix-$vol"
+    echo "Snapshotting volume $volume"
+    openstack snapshot create --force --name "$volume-$today" "$volume" -f yaml
+    [ $? -eq 0 ] || let vol_errors++
+    echo
+done
+
+let errors=($vm_errors + $vol_errors)
+if [ $vm_errors -ne 0 ]; then
+    echo "ERROR: $vm_errors server snapshots failed"
+fi
+if [ $vol_errors -ne 0 ]; then
+    echo "ERROR: $vol_errors volume snapshots failed"
+fi
+exit $errors

--- a/scripts/os-idr-snapshot2image.sh
+++ b/scripts/os-idr-snapshot2image.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Convert a volume snapshot to an image
+# Argument: the volume snapshot name or ID
+
+set -e
+set -u
+
+SNAPSHOT="$1"
+SIZE=$(openstack volume snapshot show "$SNAPSHOT" -f json | jq -r ".size")
+TODAY=$(date +%Y%m%d)
+
+# Snapshot -> Volume
+DESCRIPTION="Created $TODAY from Snapshot $SNAPSHOT"
+if openstack volume show "$SNAPSHOT"; then
+    echo "Volume $SNAPSHOT already exists, skipping"
+else
+    echo "Creating volume $SNAPSHOT ($SIZE GB)"
+    time openstack volume create --snapshot "$SNAPSHOT" "$SNAPSHOT" \
+        --size "$SIZE" --description "$DESCRIPTION"
+
+    while [ $(openstack volume show "$SNAPSHOT" -f json | jq -r ".status") != "available" ]; do
+        echo -n .
+        sleep 10
+    done
+    echo
+    echo "Created volume $SNAPSHOT"
+fi
+
+# Volume -> Image
+DESCRIPTION="Created $TODAY from Volume $SNAPSHOT"
+if openstack image show "$SNAPSHOT"; then
+    echo "Image $SNAPSHOT already exists, skipping"
+else
+    echo "Creating image $SNAPSHOT"
+    time openstack image create --volume "$SNAPSHOT" "$SNAPSHOT"
+
+    while [ $(openstack image show "$SNAPSHOT" -f json | jq -r ".status") != "active" ]; do
+        echo -n .
+        sleep 10
+    done
+    echo
+    echo "Created image $SNAPSHOT"
+fi
+
+echo "You can download this image by running"
+echo openstack image save --file "$SNAPSHOT" "$SNAPSHOT"


### PR DESCRIPTION
Adds copies of the main openstack IDR scripts which are currently in several different repositories:
- `os-idr-delete.sh`: Deletes everything in a given IDR environment
- `os-idr-snapshot.sh`: Snapshots important instances and volumes
- `os-idr-snapshot2image.sh`: Converts a volume snapshot into an image for transfer between clouds. Always seems to time out but in theory this should work.