### PR TITLE
IDR 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If you are deploying the IDR platform on OpenStack you should have a good workin
 
 All documents assume extensive knowledge of [OMERO](https://www.openmicroscopy.org/site/support/omero5/sysadmins/).
 
+Ansible 2.3 is required.
+Some Ansible tasks can take a long time, such as pulling Docker images.
+If you see lost connections you can try setting a keep-alive in your `.ssh/config` file, e.g. `ServerAliveInterval 30`.
+
 
 ## Documents
 

--- a/ansible/files/idr-rsync-backup.sh
+++ b/ansible/files/idr-rsync-backup.sh
@@ -3,14 +3,14 @@
 set -e
 set -u
 
-PGHOST=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.host")
-PGPASSWORD=$(su omero -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.pass")
+export PGHOST=$(su omero-server -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.host")
+export PGPASSWORD=$(su omero-server -lc "/opt/omero/server/OMERO.server/bin/omero config get omero.db.pass")
 DATE=$(date +"%Y-%m-%d")
 test -e $DATE && {
   echo $DATE already exists
   exit 1
 }
-time pg_dump -U omero idr -j 8 -Fd -f $DATE \
+time pg_dump -h $PGHOST -U omero idr -j 8 -Fd -f $DATE \
     --exclude-table-data password \
     --exclude-table-data eventlog
 chmod -R a+rX $DATE

--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -10,3 +10,4 @@ postgresql_users_databases:
   password: "{{ idr_secret_postgresql_password | default('omero') }}"
   databases: [idr]
 postgresql_server_chown_datadir: True
+postgresql_version: "9.6"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -3,4 +3,4 @@ docker_use_ipv4_nic_mtu: True
 #idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
-idr_jupyter_notebook_repo_version: "0.4.0"
+idr_jupyter_notebook_repo_version: "0.5.0"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
 #idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
-idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
+idr_jupyter_notebook_image: "imagedata/jupyter-docker:0.4.0"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
 idr_jupyter_notebook_repo_version: "0.5.0"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
 #idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.3.0"
-idr_jupyter_notebook_image: "imagedata/jupyter-docker:0.3.0"
+idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
 idr_jupyter_notebook_repo_version: "0.4.0"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -1,6 +1,6 @@
 ######################################################################
 # Shared variables
-idr_omero_release: "0.3.7"
+idr_omero_release: "0.4.0"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -226,7 +226,7 @@ nginx_proxy_streams:
 - name: idrrsync
   port: 873
   servers:
-  - "{{ omero_omero_host_ansible }}:873 max_fails=3 fail_timeout=30s"
+  - "{{ omero_downloads_host_ansible }}:873 max_fails=3 fail_timeout=30s"
   connect_timeout: "1s"
   timeout: "3s"
 

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -5,8 +5,8 @@
 ######################################################################
 # nginx and SSL
 
-# We need config options from 1.11
-nginx_stable_repo: False
+# The stable line is now 1.12
+nginx_stable_repo: True
 
 nginx_proxy_worker_processes: 4
 nginx_proxy_buffers: 32 16k

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -221,14 +221,23 @@ nginx_proxy_direct_locations:
 
 #nginx_proxy_set_header_host: 'idr.openmicroscopy.org'
 
-# List of backend streaming servers
-nginx_proxy_streams:
+
+# omero_downloads_host_ansible may be empty
+_nginx_proxy_streams_rsync:
 - name: idrrsync
   port: 873
   servers:
-  - "{{ omero_downloads_host_ansible }}:873 max_fails=3 fail_timeout=30s"
+  - "{{ omero_downloads_host_ansible | default(None) }}:873 max_fails=3 fail_timeout=30s"
   connect_timeout: "1s"
   timeout: "3s"
+
+# List of backend streaming servers
+nginx_proxy_streams: >
+  {{ [] +
+     ((omero_downloads_host_ansible is defined) |
+       ternary(_nginx_proxy_streams_rsync, [])
+     ) }}
+
 
 ######################################################################
 # Static webpages (/about) on proxy

--- a/ansible/idr-09-monitoring.yml
+++ b/ansible/idr-09-monitoring.yml
@@ -2,3 +2,4 @@
 # Some of this requires private configuration information
 
 - include: management.yml
+- include: management-prometheus.yml

--- a/ansible/idr-bastion.yml
+++ b/ansible/idr-bastion.yml
@@ -11,7 +11,7 @@
     {{ idr_environment | default('idr') }}-a-bastion-hosts
 
   roles:
-  - role: hosts-populate
+  - role: openmicroscopy.hosts-populate
     hosts_populate_openstack_groups:
     - "{{ idr_environment | default('idr') }}-hosts"
     - "{{ idr_environment | default('idr') }}-a-hosts"

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -34,7 +34,7 @@
   - name: docker swarm | check active
     become: yes
     shell: "docker info 2> /dev/null | sed -n 's/^Swarm: //p'"
-    always_run: yes
+    check_mode: no
     ignore_errors: yes
     register: docker_swarm_active
     changed_when: False
@@ -44,7 +44,7 @@
   - name: docker swarm | check mtu
     become: yes
     command: docker network inspect docker_gwbridge -f "{{ '{{' }} index .Options \"com.docker.network.driver.mtu\" {{ '}}' }}"
-    always_run: yes
+    check_mode: no
     #ignore_errors: yes
     register: docker_swarm_net_mtu
     when: docker_swarm_enabled

--- a/ansible/idr-downloads.yml
+++ b/ansible/idr-downloads.yml
@@ -7,7 +7,7 @@
 # TODO: Use new download-hosts group to avoid coupling this to omero-hosts
 # https://trello.com/c/ztvftdc8/154-define-download-hosts-group-for-rsync-server
 #- hosts: "{{ idr_environment | default('idr') }}-download-hosts"
-- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+- hosts: "{{ idr_environment | default('idr') }}-a-omero-hosts"
 
   roles:
 
@@ -45,12 +45,3 @@
       src: files/idr-rsync-backup.sh
       dest: /srv/omero-sql/backup.sh
       mode: 0555
-
-  - name: Get database IP
-    set_fact:
-      omero_omero_host_ansible: >-
-        {{
-          hostvars[groups[
-            idr_environment | default('idr') + '-database-hosts'][0]]
-            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
-        }}

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -53,6 +53,7 @@
     docker_container:
       name: mineotaur
       image: imagedata/mineotaur
+      restart_policy: always
       user: 1000
       entrypoint: java
       volumes:

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -1,5 +1,5 @@
 # Load hostvars
-- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+- hosts: "{{ idr_environment | default('idr') }}-a-omero-hosts"
 
 # Setup IDR Mineotaur server
 - hosts: "{{ idr_environment | default('idr') }}-a-dockermanager-hosts"
@@ -11,7 +11,7 @@
       omero_rsync_host_ansible : >-
         {{
           hostvars[groups[
-            idr_environment | default('idr') + '-omero-hosts'][0]]
+            idr_environment | default('idr') + '-a-omero-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
 
@@ -22,18 +22,30 @@
       owner: 1000
       state: directory
 
+  - name: rsync mineotaur url
+    debug:
+      msg: >-
+        {{ idr_rsync_mineotaur_url | default(
+           'rsync://' + omero_rsync_host_ansible + '/mineotaur/')
+        }}
+
   # Run as UID 1000 since this is required by the Docker container
+  # When running externally pull down the IDR data by defining:
+  # idr_rsync_mineotaur_url: "rsync://idr.openmicroscopy.org/mineotaur/"
   - name: download mineotaur data
     become: yes
     become_user: 1000
     synchronize:
-      src: "rsync://idr-demo.openmicroscopy.org/mineotaur/"
+      src: >-
+        {{
+          idr_rsync_mineotaur_url | default(
+            'rsync://' + omero_rsync_host_ansible + '/mineotaur/')
+        }}
       dest: "/data/mineotaur/"
       mode: "pull"
       owner: no
       group: no
     delegate_to: "{{ inventory_hostname }}"
-    # TODO: "rsync://{{ omero_rsync_host_ansible }}/mineotaur/" currently inaccessible due to networking
 
   # TODO: add version
   - name: enable mineotaur container

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -58,6 +58,6 @@
   roles:
   - role: openmicroscopy.redis
   - role: openmicroscopy.omero-web
-  - role: omero-web-apps
+  - role: openmicroscopy.omero-web-apps
 
   # Vars are in group_vars/omero-hosts.yml

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -4,7 +4,9 @@
 # full list of backend services to be proxied
 
 # Load hostvars (production OMERO)
-- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+- hosts: >
+    {{ idr_environment | default('idr') }}-omero-hosts
+    {{ idr_environment | default('idr') }}-a-omero-hosts
 
 # Load hostvars (jupyter), this should be the proxy idr_environment
 # suffixed with `-a`
@@ -26,6 +28,15 @@
         {{
           hostvars[groups[
             idr_environment | default('idr') + '-omero-hosts'][0]]
+            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+        }}
+
+  - name: Get rsync IP
+    set_fact:
+      omero_downloads_host_ansible: >-
+        {{
+          hostvars[groups[
+            idr_environment | default('idr') + '-a-omero-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
 

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -39,6 +39,7 @@
             idr_environment | default('idr') + '-a-omero-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
+    when: "{{ groups[idr_environment | default('idr') + '-a-omero-hosts'] is defined }}"
 
   - name: Get jupyterhub IP
     set_fact:

--- a/ansible/idr-reboot-if-kernel.yml
+++ b/ansible/idr-reboot-if-kernel.yml
@@ -12,7 +12,7 @@
     {{ idr_environment | default('idr') }}-a-hosts
     !bastion-hosts
   roles:
-  - role: reboot-server
+  - role: openmicroscopy.reboot-server
     reboot_server_timeout: 0
 
 
@@ -23,5 +23,5 @@
     {{ idr_environment | default('idr') }}-a-hosts
     &bastion-hosts
   roles:
-  - role: reboot-server
+  - role: openmicroscopy.reboot-server
     reboot_server_timeout: 0

--- a/ansible/idr-reset-users-groups.yml
+++ b/ansible/idr-reset-users-groups.yml
@@ -57,7 +57,7 @@
     {{ idr_environment | default('idr') }}-a-omero-hosts
 
   roles:
-  - omero-user
+  - openmicroscopy.omero-user
 
   post_tasks:
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -52,12 +52,12 @@
 
   - role: openmicroscopy.prometheus
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
-    prometheus_alertmanager_slack_channel: '#trash'
-    # TODO: Use the defaults in the prometheus role instead (30s 5m 3h)
-    # This is currently reduced to make testing easier
-    prometheus_alert_group_wait: 10s
-    prometheus_alert_group_interval: 1m
-    prometheus_alert_repeat_interval: 1m
+    prometheus_alertmanager_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
+    # The defaults in the prometheus role are (30s 5m 3h)
+    # When testing you may want to decrease these to make it easier
+    #prometheus_alert_group_wait: 10s
+    #prometheus_alert_group_interval: 1m
+    #prometheus_alert_repeat_interval: 1m
 
     # groupname must be unique
     prometheus_targets:

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -5,7 +5,7 @@
     {{ idr_environment | default('idr') }}-a-hosts
 
   roles:
-  - role: prometheus-node
+  - role: openmicroscopy.prometheus-node
 
 
 - hosts: >
@@ -13,7 +13,7 @@
     {{ idr_environment | default('idr') }}-a-omero-hosts
 
   roles:
-  - role: prometheus-jmx
+  - role: openmicroscopy.prometheus-jmx
   # Needed for handlers
   - role: openmicroscopy.omero-common
 
@@ -50,7 +50,7 @@
   - role: openmicroscopy.docker
     docker_use_ipv4_nic_mtu: True
 
-  - role: prometheus
+  - role: openmicroscopy.prometheus
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
     prometheus_alertmanager_slack_channel: '#trash'
     # TODO: Use the defaults in the prometheus role instead (30s 5m 3h)

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -8,13 +8,14 @@
   - role: openmicroscopy.prometheus-node
 
 
+# TODO: Do we trust the JMX monitoring agent for OMERO?
+# If not disable this playbook
 - hosts: >
     {{ idr_environment | default('idr') }}-omero-hosts
     {{ idr_environment | default('idr') }}-a-omero-hosts
 
   roles:
-  # TODO: Enable JMX monitoring?
-  #- role: openmicroscopy.prometheus-jmx
+  - role: openmicroscopy.prometheus-jmx
   # Needed for handlers
   - role: openmicroscopy.omero-common
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -13,7 +13,8 @@
     {{ idr_environment | default('idr') }}-a-omero-hosts
 
   roles:
-  - role: openmicroscopy.prometheus-jmx
+  # TODO: Enable JMX monitoring?
+  #- role: openmicroscopy.prometheus-jmx
   # Needed for handlers
   - role: openmicroscopy.omero-common
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -20,13 +20,15 @@
   - role: openmicroscopy.omero-common
 
   tasks:
+  # TODO: Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
   - name: omero prometheus agent
     become: yes
     copy:
       content: |
-        config set -- omero.jvmcfg.append.blitz "-javaagent:{{ jmx_javaagent }}=9180:/etc/prometheus/jmx-default-config.yml"
-        config set -- omero.jvmcfg.append.indexer "-javaagent:{{ jmx_javaagent }}=9181:/etc/prometheus/jmx-default-config.yml"
-        config set -- omero.jvmcfg.append.pixeldata "-javaagent:{{ jmx_javaagent }}=9182:/etc/prometheus/jmx-default-config.yml"
+        # Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
+        #config set -- omero.jvmcfg.append.blitz "-javaagent:{{ jmx_javaagent }}=9180:/etc/prometheus/jmx-default-config.yml"
+        #config set -- omero.jvmcfg.append.indexer "-javaagent:{{ jmx_javaagent }}=9181:/etc/prometheus/jmx-default-config.yml"
+        #config set -- omero.jvmcfg.append.pixeldata "-javaagent:{{ jmx_javaagent }}=9182:/etc/prometheus/jmx-default-config.yml"
       dest: "{{ omero_common_basedir }}/server/config/prometheus.omero"
     notify:
     - restart omero-server
@@ -70,24 +72,25 @@
       port: 9100
       jobname: node-exporter
 
+# TODO: Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
     - groupname: blitz
-      groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
-      - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
+      # groups:
+      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      # - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
       port: 9180
       jobname: jmx-blitz
 
     - groupname: indexer
-      groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
-      - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
+      # groups:
+      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      # - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
       port: 9181
       jobname: jmx-indexer
 
     - groupname: pixeldata
-      groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
-      - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
+      # groups:
+      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      # - "{{ idr_environment | default('idr') + '-a-omero-hosts' }}"
       port: 9182
       jobname: jmx-pixeldata
 

--- a/ansible/management.yml
+++ b/ansible/management.yml
@@ -83,3 +83,16 @@
   - role: openmicroscopy.omero-logmonitor
     omero_logmonitor_slack_token: "{{ idr_secret_omero_logmonitor_slack_token | default(None) }}"
     omero_logmonitor_slack_channel: "#idr-logs"
+
+
+# Docker slack notifications
+- hosts: >
+    {{ idr_environment | default('idr') }}-a-dockermanager-hosts
+    {{ idr_environment | default('idr') }}-a-dockerworker-hosts
+
+  roles:
+  - role: openmicroscopy.docker-slack-notifier
+    docker_slack_notifier_channel: "#idr-deployment"
+    docker_slack_notifier_username: "{{ ansible_hostname }}"
+    docker_slack_notifier_icon: ":docker:"
+    docker_slack_notifier_token: "{{ idr_secret_management_slack_webhook | default(None) }}"

--- a/ansible/management.yml
+++ b/ansible/management.yml
@@ -71,7 +71,7 @@
   - name: Get short hostname (not the same as the Ansible hostname vars)
     command: hostname -s
     register: short_hostname
-    always_run: True
+    check_mode: no
     changed_when: False
 
   - name: Set omero logmonitor bot-name

--- a/ansible/openstack-create-infrastructure.yml
+++ b/ansible/openstack-create-infrastructure.yml
@@ -77,7 +77,7 @@
       idr_vm_name: "{{ idr_environment_idr }}-omero"
       idr_vm_image: "{{ vm_image }}"
       idr_vm_flavour: "{{ vm_flavour_large }}"
-      idr_vm_omero: True
+      idr_vm_omeroreadwrite: True
       idr_vm_extra_groups:
       - "{{ idr_vm_storage_group }}"
       idr_vm_networks: >
@@ -156,7 +156,7 @@
       idr_vm_name: "{{ idr_environment_analysis }}-omero"
       idr_vm_image: "{{ vm_image }}"
       idr_vm_flavour: "{{ vm_flavour_large }}"
-      idr_vm_omero: True
+      idr_vm_omeroreadwrite: True
       idr_vm_extra_groups:
       - "{{ idr_vm_storage_group }}"
       idr_vm_networks: >

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -13,7 +13,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.cadvisor
-  version: 0.1.0
+  version: 0.1.1
 
 - src: openmicroscopy.cli-utils
   version: 1.0.0
@@ -167,14 +167,14 @@
 ######################################################################
 # External development roles
 
-- name: prometheus
+- name: openmicroscopy.prometheus
   src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.1.0.tar.gz
-  version: 0.1.0
+  version: 0.1.1
 
-- name: prometheus-jmx
+- name: openmicroscopy.prometheus-jmx
   src: https://github.com/openmicroscopy/ansible-role-prometheus-jmx/archive/0.1.0.tar.gz
   version: 0.1.0
 
-- name: prometheus-node
-  src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.0.tar.gz
-  version: 0.1.0
+- name: openmicroscopy.prometheus-node
+  src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/master.tar.gz
+  version: master

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -163,18 +163,9 @@
   src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git
   version: 1.1.0
 
+
+######################################################################
 # External development roles
-- name: omero-user
-  src: https://github.com/openmicroscopy/ansible-role-omero-user
-  version: 0.1.0
-
-- name: hosts-populate
-  src: https://github.com/openmicroscopy/ansible-role-hosts-populate
-  version: 0.1.0
-
-- name: omero-web-apps
-  src: https://github.com/openmicroscopy/ansible-role-omero-web-apps
-  version: 0.1.0
 
 - name: prometheus
   src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.1.0.tar.gz
@@ -186,8 +177,4 @@
 
 - name: prometheus-node
   src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.0.tar.gz
-  version: 0.1.0
-
-- name: reboot-server
-  src: https://github.com/openmicroscopy/ansible-role-reboot-server
   version: 0.1.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,6 +26,9 @@
 - src: openmicroscopy.haproxy
   version: 2.0.0
 
+- src: openmicroscopy.hosts-populate
+  version: 0.1.0
+
 - src: openmicroscopy.ice
   version: 2.0.0
 
@@ -68,12 +71,10 @@
 - src: openmicroscopy.nginx-ssl-selfsigned
   version: 1.0.0
 
-- name: openmicroscopy.omero-common
-  src: https://github.com/openmicroscopy/ansible-role-omero-common.git
+- src: openmicroscopy.omero-common
   version: 0.1.0
 
-- name: openmicroscopy.omego
-  src: https://github.com/openmicroscopy/ansible-role-omego.git
+- src: openmicroscopy.omego
   version: 0.1.0
 
 - src: openmicroscopy.omero-logmonitor
@@ -82,13 +83,17 @@
 - src: openmicroscopy.omero-python-deps
   version: 1.0.0
 
-- name: openmicroscopy.omero-server
-  src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
+- src: openmicroscopy.omero-server
   version: 2.0.0-m1
 
-- name: openmicroscopy.omero-web
-  src:  https://github.com/openmicroscopy/ansible-role-omero-web.git
-  version: 1.0.0-m1
+- src: openmicroscopy.omero-user
+  version: 0.1.0
+
+- src: openmicroscopy.omero-web
+  version: 1.0.0-m3
+
+- src: openmicroscopy.omero-web-apps
+  version: 0.1.0
 
 - src: openmicroscopy.openstack-volume-storage
   version: 1.0.0
@@ -98,6 +103,9 @@
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0
+
+- src: openmicroscopy.reboot-server
+  version: 0.1.0
 
 - src: openmicroscopy.redis
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -79,9 +79,8 @@
   src: https://github.com/manics/ansible-role-omego/archive/temporary-db-check.tar.gz
   version: temporary-db-check
 
-- name: openmicroscopy.omero-logmonitor
-  src: https://github.com/manics/ansible-role-omero-logmonitor/archive/decouple-web.tar.gz
-  version: decouple-web
+- src: openmicroscopy.omero-logmonitor
+  version: 2.0.0
 
 - src: openmicroscopy.omero-python-deps
   version: 1.1.0
@@ -141,8 +140,8 @@
   version: 2.0.2
 
 - name: IDR.openstack-idr-instance
-  src: https://github.com/manics/ansible-role-openstack-idr-instance/archive/omeroro.tar.gz
-  version: omeroro
+  src: https://github.com/IDR/ansible-role-openstack-idr-instance.git
+  version: 2.0.0
 
 - name: IDR.openstack-idr-instance-network
   src: https://github.com/IDR/ansible-role-openstack-idr-instance-network.git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,6 +24,10 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
+- name: openmicroscopy.docker-slack-notifier
+  src: https://github.com/manics/ansible-role-docker-slack-notifier/archive/master.tar.gz
+  version: master
+
 - src: openmicroscopy.haproxy
   version: 2.0.0
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -18,7 +18,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.docker
-  version: 1.0.0
+  version: 2.1.0
 
 - src: openmicroscopy.docker-tools
   version: 1.0.0
@@ -60,7 +60,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.nfs-share
-  version: 1.0.0
+  version: 1.0.1
 
 - src: openmicroscopy.nginx
   version: 1.0.0
@@ -81,7 +81,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.omero-python-deps
-  version: 1.0.0
+  version: 1.1.0
 
 - src: openmicroscopy.omero-server
   version: 2.0.0-m1
@@ -130,7 +130,7 @@
 
 - name: IDR.idr-jupyter
   src: https://github.com/IDR/ansible-role-idr-jupyter.git
-  version: 2.0.0
+  version: 2.0.1
 
 - name: IDR.openstack-idr-instance
   src: https://github.com/IDR/ansible-role-openstack-idr-instance.git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,10 +24,6 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- name: openmicroscopy.docker-slack-notifier
-  src: https://github.com/manics/ansible-role-docker-slack-notifier/archive/master.tar.gz
-  version: master
-
 - src: openmicroscopy.haproxy
   version: 2.0.0
 
@@ -167,6 +163,10 @@
 ######################################################################
 # External development roles
 
+- name: openmicroscopy.docker-slack-notifier
+  src: https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/archive/0.0.1.tar.gz
+  version: 0.0.1
+
 - name: openmicroscopy.prometheus
   src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.1.0.tar.gz
   version: 0.1.1
@@ -176,5 +176,5 @@
   version: 0.1.0
 
 - name: openmicroscopy.prometheus-node
-  src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/master.tar.gz
-  version: master
+  src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.1.tar.gz
+  version: 0.1.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,6 @@
 ---
 
+######################################################################
 # External Ansible roles required by this repository
 
 # TODO: check ordering of these dependencies to ensure nested dependencies
@@ -30,18 +31,16 @@
   version: 0.1.0
 
 - src: openmicroscopy.ice
-  version: 2.0.0
+  version: 2.1.0
 
-- name: openmicroscopy.java
-  src: https://github.com/openmicroscopy/ansible-role-java/archive/master.tar.gz
-  version: master
+- src: openmicroscopy.java
+  version: 2.0.1
 
 - src: openmicroscopy.jekyll-build
-  version: 1.0.0
+  version: 1.1.0
 
-- name: openmicroscopy.local-accounts
-  src: https://github.com/manics/ansible-role-local-accounts/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.local-accounts
+  version: 1.0.1
 
 - src: openmicroscopy.logrotate
   version: 1.0.0
@@ -77,8 +76,9 @@
 - src: openmicroscopy.omero-common
   version: 0.1.0
 
-- src: openmicroscopy.omego
-  version: 0.1.0
+- name: openmicroscopy.omego
+  src: https://github.com/manics/ansible-role-omego/archive/temporary-db-check.tar.gz
+  version: temporary-db-check
 
 - name: openmicroscopy.omero-logmonitor
   src: https://github.com/manics/ansible-role-omero-logmonitor/archive/decouple-web.tar.gz
@@ -88,11 +88,12 @@
   version: 1.1.0
 
 - name: openmicroscopy.omero-server
-  src: https://github.com/manics/ansible-role-omero-server/archive/devel2.tar.gz
+  src: https://github.com/manics/ansible-role-omero-server/archive/devel.tar.gz
   version: devel
 
-- src: openmicroscopy.omero-user
-  version: 0.1.0
+- name: openmicroscopy.omero-user
+  src: https://github.com/manics/ansible-role-omero-user/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.omero-web
   version: 1.0.0-m3
@@ -100,8 +101,9 @@
 - src: openmicroscopy.omero-web-apps
   version: 0.1.0
 
-- src: openmicroscopy.openstack-volume-storage
-  version: 1.0.0
+- name: openmicroscopy.openstack-volume-storage
+  src: https://github.com/manics/ansible-role-openstack-volume-storage/archive/ansible23.tar.gz
+  version: ansible23
 
 - src: openmicroscopy.postgresql
   version: 2.0.0
@@ -109,8 +111,9 @@
 - src: openmicroscopy.python-pydata
   version: 1.0.0
 
-- src: openmicroscopy.reboot-server
-  version: 0.1.0
+- name: openmicroscopy.reboot-server
+  src: https://github.com/manics/ansible-role-reboot-server/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.redis
   version: 1.0.0
@@ -118,8 +121,9 @@
 - src: openmicroscopy.rsync-server
   version: 1.0.0
 
-- src: openmicroscopy.selinux-utils
-  version: 1.0.1
+- name: openmicroscopy.selinux-utils
+  src: https://github.com/manics/ansible-role-selinux-utils/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0
@@ -127,31 +131,36 @@
 - src: openmicroscopy.sudoers
   version: 1.0.0
 
-- src: openmicroscopy.upgrade-distpackages
-  version: 1.0.0
+- name: openmicroscopy.upgrade-distpackages
+  src: https://github.com/manics/ansible-role-upgrade-distpackages/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.versioncontrol-utils
   version: 1.0.0
 
+
+######################################################################
+# External IDR roles
+
 - name: IDR.idr-jupyter
   src: https://github.com/IDR/ansible-role-idr-jupyter.git
-  version: 2.0.1
+  version: 2.0.2
 
 - name: IDR.openstack-idr-instance
-  src: https://github.com/IDR/ansible-role-openstack-idr-instance.git
-  version: 1.0.2
+  src: https://github.com/manics/ansible-role-openstack-idr-instance/archive/omeroro.tar.gz
+  version: omeroro
 
 - name: IDR.openstack-idr-instance-network
-  src: https://github.com/IDR/ansible-role-openstack-idr-instance-network.git
-  version: 1.1.0
+  src: https://github.com/manics/ansible-role-openstack-idr-instance-network/archive/deprecations.tar.gz
+  version: deprecations
 
 - name: IDR.openstack-idr-keypairs
   src: https://github.com/IDR/ansible-role-openstack-idr-keypairs.git
   version: 1.0.0
 
 - name: IDR.openstack-idr-network
-  src: https://github.com/IDR/ansible-role-openstack-idr-network.git
-  version: 2.0.1
+  src: https://github.com/manics/ansible-role-openstack-idr-network.git
+  version: external-mult
 
 - name: IDR.openstack-idr-security-groups
   src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -54,9 +54,8 @@
 - src: openmicroscopy.munin-node
   version: 1.2.1-openmicroscopy1
 
-- name: openmicroscopy.network-cloud-interfaces
-  src: https://github.com/manics/ansible-role-network-cloud-interfaces/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.network-cloud-interfaces
+  version: 1.2.1
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0
@@ -91,9 +90,8 @@
   src: https://github.com/manics/ansible-role-omero-server/archive/devel.tar.gz
   version: devel
 
-- name: openmicroscopy.omero-user
-  src: https://github.com/manics/ansible-role-omero-user/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.omero-user
+  version: 0.1.1
 
 - src: openmicroscopy.omero-web
   version: 1.0.0-m3
@@ -101,9 +99,8 @@
 - src: openmicroscopy.omero-web-apps
   version: 0.1.0
 
-- name: openmicroscopy.openstack-volume-storage
-  src: https://github.com/manics/ansible-role-openstack-volume-storage/archive/ansible23.tar.gz
-  version: ansible23
+- src: openmicroscopy.openstack-volume-storage
+  version: 1.1.0
 
 - src: openmicroscopy.postgresql
   version: 2.0.0
@@ -111,9 +108,8 @@
 - src: openmicroscopy.python-pydata
   version: 1.0.0
 
-- name: openmicroscopy.reboot-server
-  src: https://github.com/manics/ansible-role-reboot-server/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.reboot-server
+  version: 0.1.1
 
 - src: openmicroscopy.redis
   version: 1.0.0
@@ -121,9 +117,8 @@
 - src: openmicroscopy.rsync-server
   version: 1.0.0
 
-- name: openmicroscopy.selinux-utils
-  src: https://github.com/manics/ansible-role-selinux-utils/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.selinux-utils
+  version: 1.0.2
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0
@@ -131,9 +126,8 @@
 - src: openmicroscopy.sudoers
   version: 1.0.0
 
-- name: openmicroscopy.upgrade-distpackages
-  src: https://github.com/manics/ansible-role-upgrade-distpackages/archive/deprecations.tar.gz
-  version: deprecations
+- src: openmicroscopy.upgrade-distpackages
+  version: 1.0.1
 
 - src: openmicroscopy.versioncontrol-utils
   version: 1.0.0
@@ -151,16 +145,16 @@
   version: omeroro
 
 - name: IDR.openstack-idr-instance-network
-  src: https://github.com/manics/ansible-role-openstack-idr-instance-network/archive/deprecations.tar.gz
-  version: deprecations
+  src: https://github.com/IDR/ansible-role-openstack-idr-instance-network.git
+  version: 1.1.1
 
 - name: IDR.openstack-idr-keypairs
   src: https://github.com/IDR/ansible-role-openstack-idr-keypairs.git
-  version: 1.0.0
+  version: 1.1.0
 
 - name: IDR.openstack-idr-network
-  src: https://github.com/manics/ansible-role-openstack-idr-network.git
-  version: external-mult
+  src: https://github.com/IDR/ansible-role-openstack-idr-network.git
+  version: 3.0.0
 
 - name: IDR.openstack-idr-security-groups
   src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -37,7 +37,7 @@
   version: 2.0.1
 
 - src: openmicroscopy.jekyll-build
-  version: 1.1.0
+  version: 1.1.1
 
 - src: openmicroscopy.local-accounts
   version: 1.0.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -75,9 +75,8 @@
 - src: openmicroscopy.omero-common
   version: 0.1.0
 
-- name: openmicroscopy.omego
-  src: https://github.com/manics/ansible-role-omego/archive/temporary-db-check.tar.gz
-  version: temporary-db-check
+- src: openmicroscopy.omego
+  version: 0.1.0
 
 - src: openmicroscopy.omero-logmonitor
   version: 2.0.0
@@ -85,9 +84,8 @@
 - src: openmicroscopy.omero-python-deps
   version: 1.1.0
 
-- name: openmicroscopy.omero-server
-  src: https://github.com/manics/ansible-role-omero-server/archive/devel.tar.gz
-  version: devel
+- src: openmicroscopy.omero-server
+  version: 2.0.0-m2
 
 - src: openmicroscopy.omero-user
   version: 0.1.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -32,14 +32,16 @@
 - src: openmicroscopy.ice
   version: 2.0.0
 
-- src: openmicroscopy.java
-  version: 2.0.0
+- name: openmicroscopy.java
+  src: https://github.com/openmicroscopy/ansible-role-java/archive/master.tar.gz
+  version: master
 
 - src: openmicroscopy.jekyll-build
   version: 1.0.0
 
-- src: openmicroscopy.local-accounts
-  version: 1.0.0
+- name: openmicroscopy.local-accounts
+  src: https://github.com/manics/ansible-role-local-accounts/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.logrotate
   version: 1.0.0
@@ -53,8 +55,9 @@
 - src: openmicroscopy.munin-node
   version: 1.2.1-openmicroscopy1
 
-- src: openmicroscopy.network-cloud-interfaces
-  version: 1.2.0
+- name: openmicroscopy.network-cloud-interfaces
+  src: https://github.com/manics/ansible-role-network-cloud-interfaces/archive/deprecations.tar.gz
+  version: deprecations
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0
@@ -77,14 +80,16 @@
 - src: openmicroscopy.omego
   version: 0.1.0
 
-- src: openmicroscopy.omero-logmonitor
-  version: 1.0.0
+- name: openmicroscopy.omero-logmonitor
+  src: https://github.com/manics/ansible-role-omero-logmonitor/archive/decouple-web.tar.gz
+  version: decouple-web
 
 - src: openmicroscopy.omero-python-deps
   version: 1.1.0
 
-- src: openmicroscopy.omero-server
-  version: 2.0.0-m1
+- name: openmicroscopy.omero-server
+  src: https://github.com/manics/ansible-role-omero-server/archive/devel2.tar.gz
+  version: devel
 
 - src: openmicroscopy.omero-user
   version: 0.1.0

--- a/ansible/tests/test_database.py
+++ b/ansible/tests/test_database.py
@@ -5,7 +5,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_services_running_and_enabled(Service):
-    service = Service('postgresql-9.4')
+    service = Service('postgresql-9.6')
     assert service.is_running
     assert service.is_enabled
 
@@ -19,4 +19,4 @@ def test_omero_database_created(Command):
             "'SELECT currentpatch,currentversion FROM dbpatch "
             "ORDER BY id DESC LIMIT 1;'")
     out = Command.check_output('bash -c %s', psql)
-    assert '0|OMERO5.2' == out
+    assert '0|OMERO5.3' == out

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -96,6 +96,9 @@ Warning: At present the `nova` command may be used to [attach additional network
 `nova` does not support [`clouds.yaml`](http://docs.openstack.org/developer/os-client-config/).
 This will be fixed when the `openstack` command-line client supports this feature.
 
+Occasionally you may see misleading such as `Quota exceeded for resources: ['floatingip'].`
+If this happens manually associate a floating IP with the idr-proxy server, and re-run the playbook.
+
 
 ## Other platforms
 


### PR DESCRIPTION
This is mostly a bump to requirements, many of which are roles with PRs that need to be merged and tagged.

Significant changes:
- OMERO-5.3
- Use the stable Nginx repository instead of mainline (less chance of breakages)
- PostgreSQL 9.6
- Changed the mineotaur data rsync to use an internal host (since the data should already be present on an OMERO data volume) instead of the external rsync URL

 --depends-on
- [x] https://github.com/ome/omego/pull/104 (I'm using a custom ansible-role-omego which installs a development zip)
- [x] https://github.com/openmicroscopy/ansible-role-omero-logmonitor/pull/1 (I've rolled back the test)
- [x] https://github.com/IDR/ansible-role-openstack-idr-instance/pull/4
- [x] https://github.com/ome/omego/pull/107
- [x] https://github.com/openmicroscopy/ansible-role-omero-server/pull/12
- [x] https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/
- [x] https://github.com/openmicroscopy/ansible-role-prometheus-node/pull/1#issuecomment-308984321
- [x]  https://github.com/openmicroscopy/ansible-role-jekyll-build/pull/2