### PR TITLE
Temporary workaround for rsyslog molecule/travis failure

### DIFF
--- a/ansible/molecule-playbook.yml
+++ b/ansible/molecule-playbook.yml
@@ -34,6 +34,16 @@
     - skip_ansible_lint
 
 
+# TODO: Refactor the openmicroscopy.haproxy role so that rsyslog is separate
+# syslog isn't included in the docker image
+- hosts: idr-proxy-docker
+  tasks:
+  - name: Install rsyslog
+    yum:
+      pkg: rsyslog
+      state: present
+
+
 # The playbook to be tested
 - include: idr-01-install-idr.yml
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@
   version: 0.1.1
 
 - src: openmicroscopy.ice
-  version: 2.1.0
+  version: 2.1.1
 
 - src: openmicroscopy.java
   version: 2.0.1


### PR DESCRIPTION
This is a workaround to get molecule/travis passing on master.

Follow-up on https://trello.com/c/9KkfveSV/64-refactor-rsyslog-in-openmicroscopyhaproxy
