### PR TITLE
More prometheus monitoring (IDR-0.4.2)

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -271,7 +271,8 @@ nginx_proxy_sites: "{{ _nginx_proxy_sites + (idr_proxy_additional_sites | defaul
 ######################################################################
 # Other
 
-#nginx_proxy_block_locations:
+nginx_proxy_block_locations:
+- "^~ /django_prometheus"
 #- "^~ /login"
 
 #nginx_proxy_set_header_host: 'idr.openmicroscopy.org'

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -18,15 +18,15 @@
   - role: openmicroscopy.omero-common
 
   tasks:
-  # TODO: Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
+  # TODO: Requires a custom build from HEAD
   - name: omero prometheus agent
     become: yes
     copy:
       content: |
-        # Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
-        #config set -- omero.jvmcfg.append.blitz "-javaagent:{{ jmx_javaagent }}=9180:/etc/prometheus/jmx-default-config.yml"
-        #config set -- omero.jvmcfg.append.indexer "-javaagent:{{ jmx_javaagent }}=9181:/etc/prometheus/jmx-default-config.yml"
-        #config set -- omero.jvmcfg.append.pixeldata "-javaagent:{{ jmx_javaagent }}=9182:/etc/prometheus/jmx-default-config.yml"
+        # Requires https://github.com/prometheus/jmx_exporter/pull/162
+        config set -- omero.jvmcfg.append.blitz "-javaagent:{{ jmx_javaagent }}=9180:/etc/prometheus/jmx-default-config.yml"
+        config set -- omero.jvmcfg.append.indexer "-javaagent:{{ jmx_javaagent }}=9181:/etc/prometheus/jmx-default-config.yml"
+        config set -- omero.jvmcfg.append.pixeldata "-javaagent:{{ jmx_javaagent }}=9182:/etc/prometheus/jmx-default-config.yml"
       dest: "{{ omero_common_basedir }}/server/config/prometheus.omero"
     notify:
     - restart omero-server
@@ -92,21 +92,24 @@
       jobname: node-exporter
 
 # TODO: Disabled due to https://github.com/prometheus/jmx_exporter/issues/156
+# Currently testing using a custom build from HEAD
+# https://github.com/prometheus/jmx_exporter/pull/162
+# https://github.com/prometheus/jmx_exporter/commit/5b180affbefa445088d4608b9640ca404ce91ae2
     - groupname: blitz
-      # groups:
-      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      groups:
+      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
       port: 9180
       jobname: jmx-blitz
 
     - groupname: indexer
-      # groups:
-      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      groups:
+      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
       port: 9181
       jobname: jmx-indexer
 
     - groupname: pixeldata
-      # groups:
-      # - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      groups:
+      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
       port: 9182
       jobname: jmx-pixeldata
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -198,17 +198,20 @@
       port: 9180
       jobname: jmx-blitz
 
-    - groupname: indexer
-      groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
-      port: 9181
-      jobname: jmx-indexer
-
-    - groupname: pixeldata
-      groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
-      port: 9182
-      jobname: jmx-pixeldata
+    # TODO: indexer and pixeldata are currently broken (fail to start)on
+    # metadata53 due to the readonly work. These two targets should be
+    # reenabled when they are fixed:
+    # - groupname: indexer
+    #   groups:
+    #   - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+    #   port: 9181
+    #   jobname: jmx-indexer
+    #
+    # - groupname: pixeldata
+    #   groups:
+    #   - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+    #   port: 9182
+    #   jobname: jmx-pixeldata
 
     - groupname: cadvisor
       groups:

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -31,6 +31,28 @@
     notify:
     - restart omero-server
 
+  - name: omero-web django prometheus install
+    become: yes
+    pip:
+      name: django_prometheus
+      state: present
+      version: 1.0.8
+      virtualenv: "{{ omero_common_basedir }}/web/venv"
+      virtualenv_site_packages: yes
+    notify:
+    - restart omero-web
+
+  - name: omero-web django prometheus configure
+    become: yes
+    copy:
+      content: |
+        config append -- omero.web.middleware '{"index":0, "class": "django_prometheus.middleware.PrometheusBeforeMiddleware"}'
+        config append -- omero.web.middleware '{"index":1000, "class": "django_prometheus.middleware.PrometheusAfterMiddleware"}'
+        config append -- omero.web.apps '"django_prometheus"'
+      dest: "{{ omero_common_basedir }}/web/config/django-prometheus.omero"
+    notify:
+    - restart omero-web
+
   vars:
     # prometheus-jmx automatically creates this:
     jmx_javaagent: /opt/prometheus/jars/jmx_prometheus_javaagent.jar
@@ -94,6 +116,13 @@
       - "{{ idr_environment | default('idr') + '-dockerworker-hosts' }}"
       port: 9280
       jobname: cadvisor-docker
+
+    - groupname: omero-web
+      groups:
+      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      port: 80
+      jobname: django
+      metrics_path: /django_prometheus/metrics
 
     prometheus_http_2xx_internal_targets: >
       {{

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -35,7 +35,8 @@
     become: yes
     pip:
       #name: django_prometheus
-      name: https://github.com/manics/django-prometheus/archive/1.0.9-ome1.zip
+      #name: https://github.com/manics/django-prometheus/archive/1.0.9-ome1.zip
+      name: https://github.com/manics/django-prometheus/archive/pr46.zip
       state: present
       #version: v1.0.8
       virtualenv: "{{ omero_common_basedir }}/web/venv"

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -99,13 +99,15 @@
 
   tasks:
 
+  # TODO: If we keep this move to a separate repo
   - name: prometheus-omero-py | install prometheus-omero-py
     become: yes
     git:
       dest: /opt/prometheus-omero-py/src
       force: yes
       repo: https://gist.github.com/238a63cfd9c2fb8a450252d79e609296.git
-      version: HEAD
+      #version: HEAD
+      version: dbcb32b5bd212ff9dd1060808f2fa850194ab2d1
     notify:
     - restart prometheus-omero-py
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -35,10 +35,9 @@
     become: yes
     pip:
       #name: django_prometheus
-      #name: https://github.com/manics/django-prometheus/archive/1.0.9-ome1.zip
-      name: https://github.com/manics/django-prometheus/archive/pr46.zip
+      name: https://github.com/IDR/django-prometheus/archive/v1.0.10-IDR1.zip
       state: present
-      #version: v1.0.8
+      #version: v
       virtualenv: "{{ omero_common_basedir }}/web/venv"
       virtualenv_site_packages: yes
     notify:

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -90,6 +90,71 @@
     jmx_javaagent: /opt/prometheus/jars/jmx_prometheus_javaagent.jar
 
 
+# prometheus-omero-py session monitoring
+# TODO: Consider moving this into a role
+- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+
+  roles:
+  - role: openmicroscopy.versioncontrol-utils
+
+  tasks:
+
+  - name: prometheus-omero-py | install prometheus-omero-py
+    become: yes
+    git:
+      dest: /opt/prometheus-omero-py/src
+      force: yes
+      repo: https://gist.github.com/238a63cfd9c2fb8a450252d79e609296.git
+      version: HEAD
+    notify:
+    - restart prometheus-omero-py
+
+  - name: prometheus-omero-py | setup virtualenv
+    become: yes
+    pip:
+      requirements: /opt/prometheus-omero-py/src/requirements.txt
+      state: present
+      virtualenv: /opt/prometheus-omero-py/venv
+      virtualenv_site_packages: yes
+    notify:
+    - restart prometheus-omero-py
+
+  - name: prometheus-omero-py | systemd service
+    become: yes
+    copy:
+      dest: /etc/systemd/system/prometheus-omero-py.service
+      src: /opt/prometheus-omero-py/src/prometheus-omero-py-metrics.service
+      remote_src: True
+    notify:
+    - restart prometheus-omero-py
+
+  - name: prometheus-omero-py | options
+    become: yes
+    copy:
+      content: >
+        OPTIONS="--host localhost --listen 9171 --verbose --interval 15"
+      dest: /etc/sysconfig/prometheus-omero-py
+    notify:
+    - restart prometheus-omero-py
+
+  - name: prometheus-omero-py | enable service
+    become: yes
+    systemd:
+      daemon_reload: yes
+      enabled: yes
+      name: prometheus-omero-py
+      state: started
+
+  handlers:
+  - name: restart prometheus-omero-py
+    become: yes
+    systemd:
+      daemon_reload: yes
+      enabled: yes
+      name: prometheus-omero-py
+      state: restarted
+
+
 - hosts: >
     {{ idr_environment | default('idr') }}-dockermanager-hosts
     {{ idr_environment | default('idr') }}-dockerworker-hosts
@@ -158,6 +223,12 @@
       port: 80
       jobname: django
       metrics_path: /django_prometheus/metrics
+
+    - groupname: omero-sessions
+      groups:
+      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      port: 9171
+      jobname: omero-sessions
 
     prometheus_http_2xx_internal_targets: >
       {{

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -34,9 +34,10 @@
   - name: omero-web django prometheus install
     become: yes
     pip:
-      name: django_prometheus
+      #name: django_prometheus
+      name: https://github.com/manics/django-prometheus/archive/1.0.9-ome1.zip
       state: present
-      version: 1.0.8
+      #version: v1.0.8
       virtualenv: "{{ omero_common_basedir }}/web/venv"
       virtualenv_site_packages: yes
     notify:
@@ -49,7 +50,38 @@
         config append -- omero.web.middleware '{"index":0, "class": "django_prometheus.middleware.PrometheusBeforeMiddleware"}'
         config append -- omero.web.middleware '{"index":1000, "class": "django_prometheus.middleware.PrometheusAfterMiddleware"}'
         config append -- omero.web.apps '"django_prometheus"'
+
+        config set -- omero.web.wsgi_args '--config file:/opt/omero/web/config/gunicorn-config.py'
       dest: "{{ omero_common_basedir }}/web/config/django-prometheus.omero"
+    notify:
+    - restart omero-web
+
+  - name: omero-web gunicorn prometheus configure
+    become: yes
+    copy:
+      content: |
+        from prometheus_client import multiprocess
+        def child_exit(server, worker):
+            multiprocess.mark_process_dead(worker.pid)
+      dest: "{{ omero_common_basedir }}/web/config/gunicorn-config.py"
+    notify:
+    - restart omero-web
+
+  - name: omero-web service.d directory
+    become: yes
+    file:
+      path: /etc/systemd/system/omero-web.service.d
+      state: directory
+
+  - name: omero-web service.d prometheus
+    become: yes
+    copy:
+      content: |
+        [Service]
+        Environment="prometheus_multiproc_dir=/opt/omero/web/OMERO.web/var/prometheus"
+        ExecStartPre=/bin/sh -c '/usr/bin/rm -rf "$prometheus_multiproc_dir" && \
+            /usr/bin/mkdir -p "$prometheus_multiproc_dir"'
+      dest: /etc/systemd/system/omero-web.service.d/prometheus.conf
     notify:
     - restart omero-web
 

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -105,16 +105,15 @@
     git:
       dest: /opt/prometheus-omero-py/src
       force: yes
-      repo: https://gist.github.com/238a63cfd9c2fb8a450252d79e609296.git
-      #version: HEAD
-      version: dbcb32b5bd212ff9dd1060808f2fa850194ab2d1
+      repo: https://github.com/IDR/omero-prometheus-tools.git
+      version: 0.0.1
     notify:
     - restart prometheus-omero-py
 
   - name: prometheus-omero-py | setup virtualenv
     become: yes
     pip:
-      requirements: /opt/prometheus-omero-py/src/requirements.txt
+      requirements: /opt/prometheus-omero-py/src/sessions/requirements.txt
       state: present
       virtualenv: /opt/prometheus-omero-py/venv
       virtualenv_site_packages: yes
@@ -125,7 +124,7 @@
     become: yes
     copy:
       dest: /etc/systemd/system/prometheus-omero-py.service
-      src: /opt/prometheus-omero-py/src/prometheus-omero-py-metrics.service
+      src: /opt/prometheus-omero-py/src/sessions/prometheus-omero-py-metrics.service
       remote_src: True
     notify:
     - restart prometheus-omero-py

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -66,11 +66,8 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-#- src: openmicroscopy.nginx-proxy
-#  version: 1.3.0
-- name: openmicroscopy.nginx-proxy
-  src: https://github.com/manics/ansible-role-nginx-proxy/archive/nginx_proxy_block_locations.tar.gz
-  verison: nginx_proxy_block_locations
+- src: openmicroscopy.nginx-proxy
+  version: 1.5.1
 
 - src: openmicroscopy.nginx-ssl-selfsigned
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -170,9 +170,10 @@
   src: https://github.com/manics/ansible-role-prometheus/archive/metrics_path.tar.gz
   version: metrics_path
 
+# TODO: Update and tag
 - name: openmicroscopy.prometheus-jmx
-  src: https://github.com/openmicroscopy/ansible-role-prometheus-jmx/archive/0.1.0.tar.gz
-  version: 0.1.0
+  src: https://github.com/manics/ansible-role-prometheus-jmx/archive/jmx_prometheus_javaagent_head.tar.gz
+  version: jmx_prometheus_javaagent_head
 
 - name: openmicroscopy.prometheus-node
   src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.1.tar.gz

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -165,15 +165,13 @@
   src: https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/archive/0.0.2.tar.gz
   version: 0.0.2
 
-# TODO: Update and tag
 - name: openmicroscopy.prometheus
-  src: https://github.com/manics/ansible-role-prometheus/archive/metrics_path.tar.gz
-  version: metrics_path
+  src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.2.0.tar.gz
+  version: 0.2.0
 
-# TODO: Update and tag
 - name: openmicroscopy.prometheus-jmx
-  src: https://github.com/manics/ansible-role-prometheus-jmx/archive/jmx_prometheus_javaagent_head.tar.gz
-  version: jmx_prometheus_javaagent_head
+  src: https://github.com/openmicroscopy/ansible-role-prometheus-jmx/archive/0.1.1.tar.gz
+  version: 0.1.1
 
 - name: openmicroscopy.prometheus-node
   src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.1.tar.gz

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -165,9 +165,10 @@
   src: https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/archive/0.0.2.tar.gz
   version: 0.0.2
 
+# TODO: Update and tag
 - name: openmicroscopy.prometheus
-  src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.1.0.tar.gz
-  version: 0.1.1
+  src: https://github.com/manics/ansible-role-prometheus/archive/metrics_path.tar.gz
+  version: metrics_path
 
 - name: openmicroscopy.prometheus-jmx
   src: https://github.com/openmicroscopy/ansible-role-prometheus-jmx/archive/0.1.0.tar.gz

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -66,8 +66,11 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-- src: openmicroscopy.nginx-proxy
-  version: 1.3.0
+#- src: openmicroscopy.nginx-proxy
+#  version: 1.3.0
+- name: openmicroscopy.nginx-proxy
+  src: https://github.com/manics/ansible-role-nginx-proxy/archive/nginx_proxy_block_locations.tar.gz
+  verison: nginx_proxy_block_locations
 
 - src: openmicroscopy.nginx-ssl-selfsigned
   version: 1.0.0


### PR DESCRIPTION
Adds more Prometheus monitoring, some of which was used to investigate performance problems in the openmicroscopy `metadata53`branch:
- Installs a custom version of `django_prometheus`
  - Changes were made to `django_prometheus` to work with multi-process wsgi/gunicorn (the alternative was code changes to OMERO.web)
  - Subsequently someone has opened an upstream PR with the same functionality: https://github.com/korfuri/django-prometheus/pull/46 so we can revert to upstream when it's released
- Re-enables the jmx-exporter, using a custom build
  - The problems we had with the jmx-exporter should be fixed by https://github.com/prometheus/jmx_exporter/pull/162 so I made a devel build to test this: https://github.com/openmicroscopy/ansible-role-prometheus-jmx/pull/1
  - Subsequently there was an upstream release https://github.com/prometheus/jmx_exporter/releases/tag/parent-0.10 so we can revert to upstream in the next deployment after testing
- Adds a small python util for monitoring the number of omero sessions: https://gist.github.com/manics/238a63cfd9c2fb8a450252d79e609296

Requirements:
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-prometheus/pull/4
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-prometheus-jmx/pull/1
