### PR TITLE
OMERO.web performance/errors (IDR-0.4.2)

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -137,6 +137,12 @@ omero_web_config_set:
   omero.web.ui.metadata_panes: []
   omero.web.wsgi_timeout: "{{ idr_omero_web_timeout | default(60) }}"
 
+# TODO: This needs careful review of the code
+# https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.0-m2/components/tools/OmeroWeb/omeroweb/decorators.py#L305
+  omero.web.public.cache.enabled: True
+  omero.web.public.cache.timeout: 60
+
+
 
 ######################################################################
 # Plugins and additional web configuration

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -58,11 +58,6 @@
 
   - role: openmicroscopy.omero-server
 
-  # Use a single redis server for shared web sessions
-  # TODO: Add omeroweb hosts group
-  - role: openmicroscopy.redis
-    redis_listen: 0.0.0.0
-
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
 
 
@@ -70,18 +65,8 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-omero-hosts
 
-  pre_tasks:
-  - name: Get redis IP
-    set_fact:
-      omero_redis_host_ansible: >-
-        {{
-          hostvars[groups[
-            idr_environment | default('idr') + '-omeroreadwrite-hosts'][0]]
-            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
-        }}
-    when: "{{ groups[idr_environment | default('idr') + '-omeroreadwrite-hosts'] is defined }}"
-
   roles:
+  - role: openmicroscopy.redis
   - role: openmicroscopy.omero-web
   - role: openmicroscopy.omero-web-apps
 


### PR DESCRIPTION
Changes made as a response to failures in release testing: https://trello.com/c/isuehtZ6/78-release-testing-failures
- Uses a separate Redis server for each OMERO.web instance. This shouldn't be necessary but was done to rule out as many potential issues as possible, it may be reverted in future.
- Enables the little known never tested `omero.web.public.cache.enabled` option. See https://trello.com/c/Di7IgStr/80-omerowebpubliccacheenabled and linked conversations