### PR TITLE
Use a shared OMERO idr-metadata directory (IDR-0.4.2)

### DIFF
--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -9,6 +9,7 @@
 
   pre_tasks:
   - name: Create idr-metadata directory
+    become: yes
     file:
       path: /data/idr-metadata
       state: directory

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -7,6 +7,12 @@
 # OMERO read-write fileserver for OMERO read-only
 - hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
 
+  pre_tasks:
+  - name: Create idr-metadata directory
+    file:
+      path: /data/idr-metadata
+      state: directory
+
   roles:
 
   - role: openmicroscopy.nfs-share
@@ -18,6 +24,9 @@
       # TODO: Limit which hosts can write to this dir
       - host: "*"
         options: 'rw'
+      /data/idr-metadata:
+      - host: "*"
+        options: 'ro'
 
   # Include restart handlers
   - role: openmicroscopy.omero-common
@@ -53,6 +62,9 @@
     - path: /data/BioFormatsCache
       location: "{{ omero_fileserver_host_ansible }}:/data/BioFormatsCache"
       opts: rw,sync
+    - path: /data/idr-metadata
+      location: "{{ omero_fileserver_host_ansible }}:/data/idr-metadata"
+      opts: ro
 
   # Include restart handlers
   - role: openmicroscopy.omero-common


### PR DESCRIPTION
The idr-metadata directory is intrinsically linked to the OMERO ManagedRepository, so the read-only servers should use the read-write server's copy.