### PR TITLE
Front-end proxy (IDR-0.4.2)

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -27,7 +27,7 @@ nginx_proxy_websockets_enable: True
 nginx_proxy_upstream_servers:
 - name: omeroreadonly
   balance: ip_hash
-  servers: "{{ omero_omeroreadonly_hosts }}"
+  servers: "{{ omero_omeroreadonly_hosts | sort }}"
 - name: omeroreadwrite
   servers: "{{ omero_omeroreadwrite_hosts }}"
 

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -88,3 +88,27 @@
   # Vars are in group_vars/omero-hosts.yml
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
+
+
+# TODO: Replace with a template using
+# https://github.com/openmicroscopy/openmicroscopy/pull/5387
+- hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
+
+  tasks:
+  - name: Set Nginx proxy timeout
+    become: yes
+    lineinfile:
+      insertafter: 'server\s*{'
+      path: /etc/nginx/conf.d/omero-web.conf
+      line: proxy_read_timeout {{ idr_omero_web_timeout }};
+      regexp: proxy_read_timeout\s+.*
+      state: present
+    notify:
+    - restart nginx
+
+  handlers:
+  - name: restart nginx
+    become: yes
+    service:
+      name: nginx
+      state: restarted


### PR DESCRIPTION
- Increases the timeout in omeroreadwrite's OMERO.web nginx.conf
  - In future this should be replaced by a template that takes advantage of https://github.com/openmicroscopy/openmicroscopy/pull/5387

Note Nginx proxy changes are also present in https://github.com/IDR/deployment/pull/36
