### PR TITLE
Pin Kubernetes/kubeadm version (IDR-0.4.2)

### DIFF
--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,5 +1,7 @@
 docker_use_ipv4_nic_mtu: True
 
+kubernetes_kube_version: 1.7.0
+
 idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -1,4 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
+kubernetes_kube_version: 1.7.0
+
 idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -1,3 +1,5 @@
+# Setup a kubernetes cluster
+# idr-docker.yml must be run first
 ---
 
 - hosts: >

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -23,3 +23,5 @@ kubernetes_init_args: >-
      , '') }}
 
 kubernetes_join_args: --token {{ kubernetes_token }} {{ kubernetes_master }}
+
+kubernetes_kube_version: ''

--- a/ansible/roles/kubernetes/tasks/common.yml
+++ b/ansible/roles/kubernetes/tasks/common.yml
@@ -46,9 +46,9 @@
   become: yes
   yum:
     name:
-    - kubeadm
-    - kubectl
-    - kubelet
+    - kubeadm{{ (kubernetes_kube_version | length > 0) | ternary('-', '') + kubernetes_kube_version }}
+    - kubectl{{ (kubernetes_kube_version | length > 0) | ternary('-', '') + kubernetes_kube_version }}
+    - kubelet{{ (kubernetes_kube_version | length > 0) | ternary('-', '') + kubernetes_kube_version }}
     - kubernetes-cni
     state: present
 


### PR DESCRIPTION
An error was introduced in kubeadm 1.7.1: https://github.com/kubernetes/kubeadm/issues/347
This pins the Kubernetes version to 1.7.0 until it's fixed in an upstream release.