### PR TITLE
Add playbook for archiving nginx and munin logs

### DIFF
--- a/ansible/decommission/archive-logs.yml
+++ b/ansible/decommission/archive-logs.yml
@@ -1,0 +1,62 @@
+# Run this before decommission a deployment
+
+- hosts: >
+    {{ idr_environment | default('idr') }}-proxy-hosts
+    {{ idr_environment | default('idr') }}-management-hosts
+
+  tasks:
+  - name: Get archive prefix
+    set_fact:
+      decommission_archive_prefix: "{{ ansible_hostname }}-{{ ansible_date_time.date | replace('-', '') }}"
+
+
+- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
+  tasks:
+
+  - name: Archive proxy nginx logs
+    become: yes
+    archive:
+      dest: /tmp/{{ decommission_archive_prefix }}-nginx.tar.gz
+      format: gz
+      path: /var/log/nginx
+    register: _decommission_archive_nginx
+
+  - name: Fetch proxy nginx logs archive
+    become: yes
+    fetch:
+      dest: /tmp/
+      flat: yes
+      src: /tmp/{{ decommission_archive_prefix }}-nginx.tar.gz
+
+  - name: Print archive information
+    debug:
+      msg: >
+        Archived {{ _decommission_archive_nginx.archived | length }} files
+        from {{ ansible_hostname }}:{{ _decommission_archive_nginx.expanded_paths | join(',') }}
+        to /tmp/{{ decommission_archive_prefix }}-nginx.tar.gz
+
+
+- hosts: "{{ idr_environment | default('idr') }}-management-hosts"
+  tasks:
+
+  - name: Archive managment munin logs
+    become: yes
+    archive:
+      dest: /tmp/{{ decommission_archive_prefix }}-munin.tar.gz
+      format: gz
+      path: /var/lib/munin
+    register: _decommission_archive_munin
+
+  - name: Fetch management munin logs archive
+    become: yes
+    fetch:
+      dest: /tmp/
+      flat: yes
+      src: /tmp/{{ decommission_archive_prefix }}-munin.tar.gz
+
+  - name: Print archive information
+    debug:
+      msg: >
+        Archived {{ _decommission_archive_munin.archived | length }} files
+        from {{ ansible_hostname }}:{{ _decommission_archive_munin.expanded_paths | join(',') }}
+        to /tmp/{{ decommission_archive_prefix }}-nginx.tar.gz


### PR DESCRIPTION
E.g.
```
PLAY [uodtest-proxy-hosts uodtest-management-hosts] ****************************

TASK [Gathering Facts] *********************************************************
ok: [e3f02fa1-06e4-42f7-9991-ad3d772affde]
ok: [65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9]

TASK [Get archive prefix] ******************************************************
ok: [e3f02fa1-06e4-42f7-9991-ad3d772affde]
ok: [65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9]

PLAY [uodtest-proxy-hosts] *****************************************************

TASK [Archive proxy nginx logs] ************************************************
changed: [e3f02fa1-06e4-42f7-9991-ad3d772affde]

TASK [Fetch proxy nginx logs archive] ******************************************
changed: [e3f02fa1-06e4-42f7-9991-ad3d772affde]

TASK [Print archive information] ***********************************************
ok: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => {
    "msg": "Archived 37 files from uodtest-proxy:/var/log/nginx to /tmp/uodtest-proxy-20170811-nginx.tar.gz\n"
}

PLAY [uodtest-management-hosts] ************************************************

TASK [Archive managment munin logs] ********************************************
ok: [65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9]

TASK [Fetch management munin logs archive] *************************************
changed: [65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9]

TASK [Print archive information] ***********************************************
ok: [65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9] => {
    "msg": "Archived 3192 files from uodtest-management:/var/lib/munin to /tmp/uodtest-management-20170811-nginx.tar.gz\n"
}

PLAY RECAP *********************************************************************
65b6b7ec-ae81-4d2e-a0db-b9342af0c9b9 : ok=5    changed=1    unreachable=0    failed=0
e3f02fa1-06e4-42f7-9991-ad3d772affde : ok=5    changed=2    unreachable=0    failed=0
```