### PR TITLE
IDR 0.4.4 merge branch

### DIFF
--- a/ansible/experimental-omero-web-addons.yml
+++ b/ansible/experimental-omero-web-addons.yml
@@ -1,4 +1,4 @@
-# Experimental: fpbioimage
+# Experimental: fpbioimage and iviewer
 
 - hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
 
@@ -26,5 +26,26 @@
         config append -- omero.web.apps '"omero_fpbioimage"'
         config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {"script_url": "fpbioimage/openwith.js", "supported_objects": ["image"], "label": "FPBioimage"}]'
       dest: "{{ omero_common_basedir }}/web/config/fpbioimage.omero"
+    notify:
+    - restart omero-web
+
+  - name: omero-web iviewer install
+    become: yes
+    pip:
+      name: omero-iviewer
+      state: present
+      version: 0.2.0
+      virtualenv: "{{ omero_common_basedir }}/web/venv"
+      virtualenv_site_packages: yes
+    notify:
+    - restart omero-web
+
+  - name: omero-web iviewer configure
+    become: yes
+    copy:
+      content: |
+        config append -- omero.web.apps '"omero_iviewer"'
+        config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"script_url": "omero_iviewer/openwith.js", "supported_objects":["image"], "label": "OMERO.iviewer"}]'
+      dest: "{{ omero_common_basedir }}/web/config/iviewer.omero"
     notify:
     - restart omero-web

--- a/ansible/grafana-dashboards/idr-postgresql.json
+++ b/ansible/grafana-dashboards/idr-postgresql.json
@@ -1,0 +1,297 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.4.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Number of rows/second queried across all tables",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "deleted",
+              "metric": "",
+              "refId": "A",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetched",
+              "refId": "B",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "inserted",
+              "metric": "",
+              "refId": "C",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "returned",
+              "refId": "D",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "updated",
+              "refId": "E",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of rows",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": "",
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pg_locks_count{datname=\"idr\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{mode}}",
+              "metric": "pg_locks_count",
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Locks",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "IDR PostgreSQL",
+  "version": 6
+}

--- a/ansible/idr-09-monitoring.yml
+++ b/ansible/idr-09-monitoring.yml
@@ -3,3 +3,4 @@
 
 - include: management.yml
 - include: management-prometheus.yml
+- include: management-grafana.yml

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -19,6 +19,7 @@
       published_ports:
       - "3000:3000"
       state: started
+      restart_policy: always
       volumes:
       - /data/grafana:/var/lib/grafana
 

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -114,6 +114,8 @@
     when: item.status == 404
     with_items:
     - "{{ grafana_get_dashboard.results }}"
+    loop_control:
+      label: "{{ item.item }}"
 
   - name: Create dashboard
     uri:
@@ -135,6 +137,8 @@
     when: item.content is defined
     with_items:
     - "{{ grafana_dashboard_json.results }}"
+    loop_control:
+      label: "{{ item.item.url }}"
 
   vars:
     grafana_dashboard_json_dir: /opt/grafana/dashboards

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -145,3 +145,4 @@
     - idr-per-server
     - idr-sessions
     - idr-vertical
+    - idr-postgresql

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -10,6 +10,9 @@
     become: yes
     docker_container:
       image: grafana/grafana
+      env:
+        # Enable anonymous login
+        GF_AUTH_ANONYMOUS_ENABLED: true
       links:
       - prometheus:prometheus
       name: grafana


### PR DESCRIPTION
This will be split into separate PRs.
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-jekyll-build/pull/9

--on-hold
--exclude

Main changes:
- `/shared` scratch space in jupyterhub notebooks
- Moved jekyll source dir to `/srv/www/src/` and added initial config to support https://github.com/IDR/idr.openmicroscopy.org/pull/24
- Prometheus monitoring for [postgres](https://github.com/openmicroscopy/ansible-role-prometheus-postgres)
- Bumped [Postgres ansible role to 3.0.0-m2](https://github.com/openmicroscopy/ansible-role-postgresql/pull/7), updated variables, enabled restricted option (omero-readonly requires TEMPORARY table privs).
- Experimental: Ensure journald logs are [kept after reboot](https://unix.stackexchange.com/a/159390), need to check for disk usage and/or log rotation
- Bumped to Kubernetes 1.7.4 (may contain deployment bugs which require deleting instead of updating a deployment when the config is changed)
- Enabled [anonymous grafana account](http://docs.grafana.org/installation/configuration/#auth-anonymous) for interactive viewing (can view over ssh tunnel without login, not safe for public proxying due to lack of protection for backend data: https://github.com/IDR/deployment/issues/49)
- Experimental: proxy [rendered pngs of grafana dashboards](http://docs.grafana.org/reference/sharing/#direct-link-rendered-image) with 60 second cache, e.g. http://example.org/grafana/idr-vertical (accepts size query parameters, need to check whether there are limits, hangs with invalid dashboard names).