### PR TITLE
Docker/kubernetes host deployment (IDR-0.4.4)

### DIFF
--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -2,9 +2,8 @@ docker_use_ipv4_nic_mtu: True
 
 kubernetes_kube_version: 1.7.4
 
-idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
-idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
-idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
-idr_jupyter_notebook_repo_version: "0.5.0"
+idr_prepull_docker_images:
+- "imagedata/jupyterhub-githubauth:latest"
+- "imagedata/jupyter-docker:develop"
 
 idr_jupyterhub_config_file: "{{ idr_secret_jupyterhub_config_file | default('kubernetes-spec/jupyterhub/config.yml') }}"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -2,8 +2,7 @@ docker_use_ipv4_nic_mtu: True
 
 kubernetes_kube_version: 1.7.4
 
-idr_prepull_docker_images:
-- "imagedata/jupyterhub-githubauth:latest"
-- "imagedata/jupyter-docker:develop"
+# Most pods are exluded from running on master
+idr_prepull_docker_images: []
 
 idr_jupyterhub_config_file: "{{ idr_secret_jupyterhub_config_file | default('kubernetes-spec/jupyterhub/config.yml') }}"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
-kubernetes_kube_version: 1.7.0
+kubernetes_kube_version: 1.7.4
 
 idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"

--- a/ansible/group_vars/dockermanager-hosts.yml
+++ b/ansible/group_vars/dockermanager-hosts.yml
@@ -6,3 +6,5 @@ idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
 idr_jupyter_notebook_repo: https://github.com/IDR/idr-notebooks.git
 idr_jupyter_notebook_repo_version: "0.5.0"
+
+idr_jupyterhub_config_file: "{{ idr_secret_jupyterhub_config_file | default('kubernetes-spec/jupyterhub/config.yml') }}"

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -2,5 +2,6 @@ docker_use_ipv4_nic_mtu: True
 
 kubernetes_kube_version: 1.7.4
 
-idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
-idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"
+idr_prepull_docker_images:
+- "imagedata/jupyterhub-githubauth:latest"
+- "imagedata/jupyter-docker:develop"

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -3,5 +3,5 @@ docker_use_ipv4_nic_mtu: True
 kubernetes_kube_version: 1.7.4
 
 idr_prepull_docker_images:
-- "imagedata/jupyterhub-githubauth:latest"
-- "imagedata/jupyter-docker:develop"
+- "imagedata/jupyterhub-githubauth:0.5.0"
+- "imagedata/jupyter-docker:0.5.0"

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -1,6 +1,6 @@
 docker_use_ipv4_nic_mtu: True
 
-kubernetes_kube_version: 1.7.0
+kubernetes_kube_version: 1.7.4
 
 idr_jupyter_hub_image: "imagedata/jupyterhub-githubauth:0.4.0"
 idr_jupyter_notebook_image: "imagedata/jupyter-docker:develop"

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -10,10 +10,6 @@
       docker_use_ipv4_nic_mtu: True
 
 
-- hosts: "{{ idr_environment | default('idr') }}-omeroreadonly-hosts"
-  # Empty playbook to force loading of omero-hosts hostvars
-
-
 - hosts: "{{ idr_environment | default('idr') }}-dockermanager-hosts"
 
   pre_tasks:
@@ -23,7 +19,6 @@
       path: /data/{{ item }}
       state: directory
     with_items:
-    - idr-notebooks
     - mineotaur
     - volumes
 
@@ -31,76 +26,10 @@
   - role: openmicroscopy.versioncontrol-utils
   - role: openmicroscopy.nfs-share
     nfs_shares:
-      /data/idr-notebooks:
-      - host: "*"
-        options: 'ro'
       /data/mineotaur:
       - host: "*"
         options: 'rw'
-#  - role: IDR.idr-jupyter
 
-  tasks:
-
-  # Notebooks
-
-  - name: jupyterhub | check if idr-notebooks repo exists
-    stat:
-      path: "{{ idr_jupyter_notebook_host_volume }}/.git/HEAD"
-    register: idr_notebook_st
-
-  # If a repo exists locally don't update it in case there are local changes
-  - name: jupyterhub | clone idr-notebooks
-    become: yes
-    git:
-      dest: "{{ idr_jupyter_notebook_host_volume }}/"
-      repo: "{{ idr_jupyter_notebook_repo }}"
-      force: no
-      version: "{{ idr_jupyter_notebook_repo_version | default('HEAD') }}"
-    when: not idr_notebook_st.stat.exists
-
-  # Symlinks to directories inside the notebook (not present on host)
-  - name: jupyterhub | create notebooks scratch
-    become: yes
-    file:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
-      force: yes
-      state: link
-    with_items:
-    - src: /scratch
-      dest: "{{ idr_jupyter_notebook_host_volume }}/scratch"
-    - src: /shared
-      dest: "{{ idr_jupyter_notebook_host_volume }}/shared"
-
-  - name: jupyterhub | update jupyter omero connection file
-    become: yes
-    blockinfile:
-      dest: "{{ idr_jupyter_notebook_host_volume }}/library/idr.py"
-      state: present
-      # This ensures the code will be indented with 4 spaces
-      block: |6
-                import random
-                HOSTNAME = str(random.choice({{ idr_jupyter_omero_host }}))
-                USERNAME = "{{ idr_jupyter_omero_user }}"
-                PASSWORD = "{{ idr_jupyter_omero_pass | quote }}"
-
-  vars:
-  # Mount this volume as /notebooks inside the docker container
-  # You must ensure it has the correct permissions for writing
-  - idr_jupyter_notebook_host_volume: /data/idr-notebooks
-  - idr_jupyter_omero_host: >
-      {{
-        groups[idr_environment | default('idr') + '-omeroreadonly-hosts'] |
-        map('extract', hostvars,
-          ['ansible_' + (idr_net_iface | default('eth0')), 'ipv4', 'address']) | list
-      }}
-  - idr_jupyter_omero_user: public
-  - idr_jupyter_omero_pass: public
-
-#  - idr_jupyter_notebook_volumes: >
-#      {
-#        '{{ idr_jupyter_notebook_host_volume }}': '/notebooks',
-#      }
 
 - hosts: "{{ idr_environment | default('idr') }}-dockerworker-hosts"
 

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -47,9 +47,7 @@
       name: "{{ item }}"
       state: "present"
       force: "{{ idr_docker_pull_latest }}"
-    with_items:
-    - "{{ idr_jupyter_hub_image }}"
-    - "{{ idr_jupyter_notebook_image }}"
+    with_items: "{{ idr_prepull_docker_images }}"
 
   vars:
   - idr_docker_pull_latest: True

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -58,14 +58,19 @@
       version: "{{ idr_jupyter_notebook_repo_version | default('HEAD') }}"
     when: not idr_notebook_st.stat.exists
 
-  # Symlink to a directory inside the notebook (not present on host)
+  # Symlinks to directories inside the notebook (not present on host)
   - name: jupyterhub | create notebooks scratch
     become: yes
     file:
-      src: /scratch
-      dest: "{{ idr_jupyter_notebook_host_volume }}/scratch"
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
       force: yes
       state: link
+    with_items:
+    - src: /scratch
+      dest: "{{ idr_jupyter_notebook_host_volume }}/scratch"
+    - src: /shared
+      dest: "{{ idr_jupyter_notebook_host_volume }}/shared"
 
   - name: jupyterhub | update jupyter omero connection file
     become: yes

--- a/ansible/idr-kubernetes-apply.yml
+++ b/ansible/idr-kubernetes-apply.yml
@@ -19,6 +19,8 @@
     - nfs-volume-provisioner/deployment.yaml
     - nfs-volume-provisioner/class.yaml
 
+    - external-omero/external-service.yml
+
     - jupyterhub/config.yml
     - jupyterhub/nfsvolume.yml
     - jupyterhub/deployment.yml

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -135,5 +135,5 @@
 
 # Now run:
 # kubectl get nodes
-# kubectl apply -f jupyterhub-config.yml -f jupyterhub-deployment.yml
+# kubectl apply -f config.yml -f jupyterhub-deployment.yml
 # kubectl logs -f deployment/jupyterhub-deployment

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -50,23 +50,18 @@
     - nfs-volume-provisioner/deployment.yaml
     - nfs-volume-provisioner/class.yaml
 
-    #- jupyterhub/config-example.yml
+    #- jupyterhub/config.yml
     # Requires the hash of the config file (see later tasks)
     #- jupyterhub/deployment.yml
+    - jupyterhub/nfsvolume.yml
 
     - mineotaur/deployment.yml
 
-  # TODO: This currently requires private vars and will fail without them.
-  # Defaults should be provided to allow public deployment
-  - name: Copy kubernetes spec templates
+  - name: Jupyterhub kubernetes config file
     become: yes
-    template:
-      src: kubernetes-spec/{{ item }}
-      dest: /opt/kubernetes-spec/{{ item }}
-    with_items:
-    - jupyterhub/nfsvolume.yml
-    - jupyterhub/config.yml
-    - mineotaur/nfsvolume.yml
+    copy:
+      src: "{{ idr_jupyterhub_config_file }}"
+      dest: /opt/kubernetes-spec/jupyterhub/config.yml
 
   # `kubectl apply` automaticallty restarts deployments if the spec
   # changes, but not if a ConfigMap changes.
@@ -82,12 +77,15 @@
     set_fact:
       kubernetes_jupyterhub_config_hash: "{{ _kubernetes_jupyterhub_config_st.stat.checksum }}"
 
-  - name: Copy kubernetes jupyterhub spec templates
+  - name: Template kubernetes spec templates
     become: yes
     template:
-      # Requires kubernetes_jupyterhub_config_hash
-      src: kubernetes-spec/jupyterhub/deployment.yml
-      dest: /opt/kubernetes-spec/jupyterhub/deployment.yml
+      src: kubernetes-spec/{{ item }}
+      dest: /opt/kubernetes-spec/{{ item }}
+    with_items:
+    - mineotaur/nfsvolume.yml
+    # Requires kubernetes_jupyterhub_config_hash
+    - jupyterhub/deployment.yml
 
 
 - hosts: >

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -2,10 +2,16 @@
 # idr-docker.yml must be run first
 ---
 
+# Load hostvars (production OMERO)
+- hosts: >
+    {{ idr_environment | default('idr') }}-omeroreadonly-hosts
+
+
 - hosts: >
     {{ idr_environment | default('idr') }}-dockermanager-hosts
 
   pre_tasks:
+
   - name: Get NFS IP
     set_fact:
       docker_nfs_host_ansible: >-
@@ -14,6 +20,28 @@
             idr_environment | default('idr') + '-dockermanager-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
+
+  - name: Get omero IP
+    set_fact:
+      docker_omeroreadonly_hosts: >-
+        {{
+          groups[idr_environment | default('idr') + '-omeroreadonly-hosts'] |
+          map('extract', hostvars,
+            ['ansible_' + (idr_net_iface | default('eth0')), 'ipv4', 'address']) | sort
+        }}
+
+  # https://stackoverflow.com/a/35608380
+  # TODO: Find a nicer way to do this instead of a set_fact loop
+  - name: Get omero kubernetes endpoint addresses
+    set_fact:
+      docker_omeroreadonly_endpoint_addresses: >
+        {{ docker_omeroreadonly_endpoint_addresses | default([]) +
+           [{
+             'ip': item
+            }]
+        }}
+    with_items:
+    - "{{ docker_omeroreadonly_hosts }}"
 
 
   roles:
@@ -37,6 +65,7 @@
     - /opt/kubernetes-spec/nfs-volume-provisioner
     - /opt/kubernetes-spec/jupyterhub
     - /opt/kubernetes-spec/mineotaur
+    - /opt/kubernetes-spec/external-omero
 
   - name: Copy kubernetes spec files
     become: yes
@@ -86,7 +115,8 @@
     - mineotaur/nfsvolume.yml
     # Requires kubernetes_jupyterhub_config_hash
     - jupyterhub/deployment.yml
-
+    # Requires docker_omeroreadonly_endpoint_addresses
+    - external-omero/external-service.yml
 
 - hosts: >
     {{ idr_environment | default('idr') }}-dockerworker-hosts


### PR DESCRIPTION
Removes notebooks from the docker hosts- this is now handled inside the `imagedata/jupyter-docker` notebook image.