### PR TITLE
More grafana dashboards. Enable anonymous access (IDR-0.4.4)

### DIFF
--- a/ansible/grafana-dashboards/idr-postgresql.json
+++ b/ansible/grafana-dashboards/idr-postgresql.json
@@ -1,0 +1,297 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.4.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Number of rows/second queried across all tables",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "deleted",
+              "metric": "",
+              "refId": "A",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "fetched",
+              "refId": "B",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "inserted",
+              "metric": "",
+              "refId": "C",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "returned",
+              "refId": "D",
+              "step": 20
+            },
+            {
+              "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\"}[5m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "updated",
+              "refId": "E",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of rows",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": "",
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pg_locks_count{datname=\"idr\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{mode}}",
+              "metric": "pg_locks_count",
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Locks",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "IDR PostgreSQL",
+  "version": 6
+}

--- a/ansible/idr-09-monitoring.yml
+++ b/ansible/idr-09-monitoring.yml
@@ -3,3 +3,4 @@
 
 - include: management.yml
 - include: management-prometheus.yml
+- include: management-grafana.yml

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -19,6 +19,7 @@
       published_ports:
       - "3000:3000"
       state: started
+      restart_policy: always
       volumes:
       - /data/grafana:/var/lib/grafana
 

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -114,6 +114,8 @@
     when: item.status == 404
     with_items:
     - "{{ grafana_get_dashboard.results }}"
+    loop_control:
+      label: "{{ item.item }}"
 
   - name: Create dashboard
     uri:
@@ -135,6 +137,8 @@
     when: item.content is defined
     with_items:
     - "{{ grafana_dashboard_json.results }}"
+    loop_control:
+      label: "{{ item.item.url }}"
 
   vars:
     grafana_dashboard_json_dir: /opt/grafana/dashboards

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -145,3 +145,4 @@
     - idr-per-server
     - idr-sessions
     - idr-vertical
+    - idr-postgresql

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -10,6 +10,9 @@
     become: yes
     docker_container:
       image: grafana/grafana
+      env:
+        # Enable anonymous login
+        GF_AUTH_ANONYMOUS_ENABLED: true
       links:
       - prometheus:prometheus
       name: grafana


### PR DESCRIPTION
Anonymous access doesn't require a login, but it still allows read-access to all data. This must be reviewed if it is to be publicly proxied.