### PR TITLE
Bump OMERO, update PG config (IDR-0.4.4)

### DIFF
--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -29,3 +29,18 @@ idr_omero_readonly_database:
   user: omeroreadonly
   password: "{{ idr_secret_postgresql_password_ro | default('omero') }}"
   statement_timeout: 60000
+
+postgresql_install_extensions: True
+
+# TODO: add a variable to easily enable/disable
+# TESTING ONLY!
+#postgresql_server_conf:
+#pg_stat_staments?
+#  shared_preload_libraries: "'pg_stat_statements'"
+#  pg_stat_statements.max: 20000
+#Database tuning?
+#  default_statistics_target = 1000
+#  maintenance_work_mem = 256MB
+#  checkpoint_completion_target = 0.9
+#  effective_cache_size = "{{ (ansible_memtotal_mb / 2) | int }}MB"
+#  work_mem = 64MB

--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -10,7 +10,11 @@ postgresql_server_auth:
   user: "{{ idr_omero_readonly_database.user }}"
   address: 0.0.0.0/0
 
-postgresql_users_databases:
+postgresql_databases:
+- name: idr
+  owner: omero
+  restrict: True
+postgresql_users:
 - user: omero
   password: "{{ idr_secret_postgresql_password | default('omero') }}"
   databases: [idr]

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.4.2-2"
+idr_omero_release: "0.4.3"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False
@@ -15,7 +15,7 @@ omero_server_checkupgrade_comparator: '!='
 
 idr_omero_omego_additional_args: "--downloadurl https://downloads.openmicroscopy.org/idr"
 # If you want to speed up Ice installation use a precompiled IcePy:
-ice_python_wheel: https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.0.2/zeroc_ice-3.6.3-cp27-cp27mu-linux_x86_64.whl
+ice_python_wheel: https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.0.3/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
 # If you're using a CI build you might need to disable omego SSL verification
 #idr_ANSIBLE_ENVIRONMENT_VARIABLES: { OMEGO_SSL_NO_VERIFY: 1 }
 

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -120,7 +120,7 @@ omero_web_config_set:
   omero.web.public.enabled: True
   omero.web.public.server_id: 1
   omero.web.public.user: public
-  omero.web.public.password: public
+  omero.web.public.password: "{{ idr_secret_public_password | default('public') }}"
   omero.web.public.url_filter: "^/({{ idr_omero_web_public_url_filters | join('|') }})"
   omero.web.login_redirect:
     redirect:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -83,6 +83,20 @@ omero_user_system: omero-server
 ######################################################################
 # openmicroscopy.omero-web role vars
 
+idr_omero_web_public_url_filters_webclient_exclude:
+- action
+- annotate_(file|tags|comment|rating|map)
+- script_ui
+- ome_tiff
+- figure_script
+
+idr_omero_web_public_url_filters:
+- webadmin/myphoto/
+- mapr/
+- webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
+- webgateway/(?!(archived_files|download_as))
+
+
 omero_web_release: "{{ idr_omero_release }}"
 # Upgrades are normally disabled, uncomment if you want to upgrade OMERO:
 omero_web_upgrade: "{{ idr_omero_upgrade }}"
@@ -107,7 +121,7 @@ omero_web_config_set:
   omero.web.public.server_id: 1
   omero.web.public.user: public
   omero.web.public.password: public
-  omero.web.public.url_filter: "^/(webadmin/myphoto/|mapr/|webclient/(?!(action|annotate_(file|tags|comment|rating|map)|script_ui|ome_tiff|figure_script))|webgateway/(?!(archived_files|download_as)))"
+  omero.web.public.url_filter: "^/({{ idr_omero_web_public_url_filters | join('|') }})"
   omero.web.login_redirect:
     redirect:
       - webindex

--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -6,6 +6,7 @@
 - include: idr-bastion.yml
 
 - include: idr-omero.yml
+- include: idr-omero-web.yml
 
 - include: idr-omero-readonly.yml
   tags:

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -167,6 +167,16 @@
 
   tasks:
 
+  - name: Allow omeroreadonly database user to create temporary tables
+    become: yes
+    become_user: postgres
+    postgresql_privs:
+      database: "{{ idr_omero_readonly_database.name }}"
+      privs: "TEMPORARY"
+      roles: "{{ idr_omero_readonly_database.user }}"
+      state: present
+      type: database
+
   - name: Give omeroreadonly database user access to database
     become: yes
     become_user: postgres

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -59,13 +59,13 @@
     nfs_share_mounts:
     - path: /data/OMERO-readonly
       location: "{{ omero_fileserver_host_ansible }}:/data/OMERO"
-      opts: ro
+      opts: ro,soft
     - path: /data/BioFormatsCache
       location: "{{ omero_fileserver_host_ansible }}:/data/BioFormatsCache"
-      opts: rw,sync
+      opts: rw,,soft,sync
     - path: /data/idr-metadata
       location: "{{ omero_fileserver_host_ansible }}:/data/idr-metadata"
-      opts: ro
+      opts: ro,soft
 
   # Include restart handlers
   - role: openmicroscopy.omero-common

--- a/ansible/idr-omero-web.yml
+++ b/ansible/idr-omero-web.yml
@@ -1,0 +1,37 @@
+# Install OMERO.web on the IDR
+
+# TODO: Add omeroweb hosts group
+- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
+
+  roles:
+  - role: openmicroscopy.redis
+  - role: openmicroscopy.omero-web
+  - role: openmicroscopy.omero-web-apps
+
+  # Vars are in group_vars/omero-hosts.yml
+
+  environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
+
+
+# TODO: Replace with a template using
+# https://github.com/openmicroscopy/openmicroscopy/pull/5387
+- hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
+
+  tasks:
+  - name: Set Nginx proxy timeout
+    become: yes
+    lineinfile:
+      insertafter: 'server\s*{'
+      path: /etc/nginx/conf.d/omero-web.conf
+      line: proxy_read_timeout {{ idr_omero_web_timeout }};
+      regexp: proxy_read_timeout\s+.*
+      state: present
+    notify:
+    - restart nginx
+
+  handlers:
+  - name: restart nginx
+    become: yes
+    service:
+      name: nginx
+      state: restarted

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -8,6 +8,15 @@
   roles:
   - role: openmicroscopy.postgresql
 
+  # tasks:
+  # - name: postgres idr pg_stat_statements extension
+  #   become: yes
+  #   become_user: postgres
+  #   postgresql_ext:
+  #     db: idr
+  #     name: pg_stat_statements
+  #     state: present
+
 
 # There are two OMERO rw and database servers, and multiple OMERO ro.
 # The next two plays set a hostvar so that the OMERO servers connect to

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -1,18 +1,9 @@
-# Example playbook for installing OMERO.server into a VM
-#
-# This is initially aimed at testing a mini-IDR, so some production tuning is
-# required (limits.d).
-# In addition the samba-client and python-pydata roles are also installed
-# as they are required for some IDR related tasks.
-# For a standard production server you won't need these.
-
-
+# Install OMERO.server on the IDR
 # Testing vars. Set:
 # - `idr_net_iface=iface` if your servers use a network interface other
 #   then eth0 for inter-machine networking
 
-- hosts: >
-    {{ idr_environment | default('idr') }}-database-hosts
+- hosts: "{{ idr_environment | default('idr') }}-database-hosts"
 
   roles:
   - role: openmicroscopy.postgresql
@@ -40,8 +31,7 @@
 # - group_vars/omeroreadwrite-hosts.yml
 # - group_vars/omeroreadonly-hosts.yml
 
-- hosts: >
-    {{ idr_environment | default('idr') }}-omero-hosts
+- hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
 
   roles:
   - role: openmicroscopy.basedeps
@@ -51,49 +41,9 @@
   - role: openmicroscopy.analysis-tools
 
 
-- hosts: >
-    {{ idr_environment | default('idr') }}-omeroreadwrite-hosts
+- hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
 
   roles:
-
   - role: openmicroscopy.omero-server
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
-
-
-# TODO: Add omeroweb hosts group
-- hosts: >
-    {{ idr_environment | default('idr') }}-omero-hosts
-
-  roles:
-  - role: openmicroscopy.redis
-  - role: openmicroscopy.omero-web
-  - role: openmicroscopy.omero-web-apps
-
-  # Vars are in group_vars/omero-hosts.yml
-
-  environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
-
-
-# TODO: Replace with a template using
-# https://github.com/openmicroscopy/openmicroscopy/pull/5387
-- hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
-
-  tasks:
-  - name: Set Nginx proxy timeout
-    become: yes
-    lineinfile:
-      insertafter: 'server\s*{'
-      path: /etc/nginx/conf.d/omero-web.conf
-      line: proxy_read_timeout {{ idr_omero_web_timeout }};
-      regexp: proxy_read_timeout\s+.*
-      state: present
-    notify:
-    - restart nginx
-
-  handlers:
-  - name: restart nginx
-    become: yes
-    service:
-      name: nginx
-      state: restarted

--- a/ansible/idr-reset-users-groups.yml
+++ b/ansible/idr-reset-users-groups.yml
@@ -21,7 +21,7 @@
 
   - name: Get omero public password
     set_fact:
-      omero_user_web_public_password: public
+      omero_user_web_public_password: "{{ idr_secret_public_password | default('public') }}"
 
   - name: Generate random OMERO root password
     command: openssl rand -base64 15

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -99,8 +99,12 @@
 - src: openmicroscopy.openstack-volume-storage
   version: 1.1.0
 
-- src: openmicroscopy.postgresql
-  version: 2.0.0
+# TODO: Update and tag
+#- src: openmicroscopy.postgresql
+#  version: 2.0.0
+- name: openmicroscopy.postgresql
+  src: https://github.com/manics/ansible-role-postgresql/archive/pg-tune.tar.gz
+  version: pg-tune
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0
@@ -176,3 +180,7 @@
 - name: openmicroscopy.prometheus-node
   src: https://github.com/openmicroscopy/ansible-role-prometheus-node/archive/0.1.1.tar.gz
   version: 0.1.1
+
+- name: openmicroscopy.prometheus-postgres
+  src: https://github.com/openmicroscopy/ansible-role-prometheus-postgres/archive/0.1.0.tar.gz
+  version: 0.1.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -100,7 +100,7 @@
   version: 1.1.0
 
 - src: openmicroscopy.postgresql
-  version: 3.0.0-m1
+  version: 3.0.0-m2
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -67,7 +67,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.nginx-proxy
-  version: 1.5.1
+  version: 1.5.2
 
 - src: openmicroscopy.nginx-ssl-selfsigned
   version: 1.0.0
@@ -85,7 +85,7 @@
   version: 1.1.0
 
 - src: openmicroscopy.omero-server
-  version: 2.0.0-m3
+  version: 2.0.0-m4
 
 - src: openmicroscopy.omero-user
   version: 0.1.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -99,12 +99,8 @@
 - src: openmicroscopy.openstack-volume-storage
   version: 1.1.0
 
-# TODO: Update and tag
-#- src: openmicroscopy.postgresql
-#  version: 2.0.0
-- name: openmicroscopy.postgresql
-  src: https://github.com/manics/ansible-role-postgresql/archive/pg-tune.tar.gz
-  version: pg-tune
+- src: openmicroscopy.postgresql
+  version: 3.0.0-m1
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0
@@ -119,7 +115,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.selinux-utils
-  version: 1.0.2
+  version: 1.0.3
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0


### PR DESCRIPTION
Additional cleanups include moving omero-web into a separate playbook

~~--depends-on https://github.com/IDR/deployment/pull/62~~ Commits from https://github.com/IDR/deployment/pull/62 are now included here