### PR TITLE
Ensure journald logs are maintained after a reboot (IDR-0.4.4)

### DIFF
--- a/ansible/idr-00-preinstall.yml
+++ b/ansible/idr-00-preinstall.yml
@@ -3,6 +3,7 @@
 
 - include: idr-networks.yml
 
+- include: idr-centos-init.yml
 - include: idr-upgrade-dist.yml
 - include: os-idr-volumes.yml
 - include: idr-dundee-nfs.yml

--- a/ansible/idr-centos-init.yml
+++ b/ansible/idr-centos-init.yml
@@ -1,0 +1,23 @@
+# Initialisation tasks for CentOS-7 VMs
+# - Persistent journald logs https://unix.stackexchange.com/a/159390
+
+- hosts: "{{ idr_environment | default('idr') }}-hosts"
+
+  tasks:
+  - name: Create persistent journald directory
+    become: yes
+    file:
+      path: /var/log/journal
+      owner: root
+      group: systemd-journal
+      mode: "u=rwx,g=rws,o=rx"
+      state: directory
+    notify:
+    - restart systemd-journald
+
+  handlers:
+  - name: restart systemd-journald
+    become: yes
+    service:
+      name: systemd-journald
+      state: restarted


### PR DESCRIPTION
The CentOS 7 cloud image default to not keeping logs over a reboot. See https://unix.stackexchange.com/a/159390