### PR TITLE
Increase application_server.max_requests from 300 to 30000 (IDR-0.4.5)

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -106,7 +106,7 @@ omero_web_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_web_config_set:
   # web
   omero.web.application_server: wsgi-tcp
-  omero.web.application_server.max_requests: 300
+  omero.web.application_server.max_requests: 30000
   omero.web.wsgi_workers: 25
   #omero.web.wsgi_timeout 30
   #omero.web.wsgi_args -- '--forwarded-allow-ips=YOUR_IP'


### PR DESCRIPTION
Our docs currently mention `omero.web.application_server.max_requests 500` without any explanation of why, or how to decide: https://docs.openmicroscopy.org/omero/5.4.0/sysadmins/unix/install-web/web-deployment.html#gunicorn-configuration

A slack discussion suggested it's not needed https://openmicroscopy.slack.com/archives/C0K5EED3R/p1507894075000132

Cards on our sysadmin board suggest web needs regular restarts: https://trello.com/c/DC5CB4Ty/34-bug-omeroweb-processes-threads

This increases the limit from 300 to 30000 in the hope that it's not really needed so having a large value won't matter, but that it's low enough so that if there are problems web workers will be restarted before they occur.

Related card:
- https://trello.com/c/n6JhjbPu/17-poor-performance-with-django-prometheus-after-several-weeks this is a disadvantage of the django-prometheus collector, but it did highlight the low value of `omero.web.application_server.max_requests`