### PR TITLE
Add vars file for upgrading to idr-ci OMERO-build

### DIFF
--- a/ansible/var-overrides/omero-ci-build.yml
+++ b/ansible/var-overrides/omero-ci-build.yml
@@ -1,0 +1,8 @@
+######################################################################
+# Include these variables to upgrade IDR OMERO to a CI build:
+#   -e @var-overrides/omero-ci-build.yml
+######################################################################
+
+idr_omero_release: OMERO-build
+idr_omero_upgrade: True
+idr_omero_omego_additional_args: "--ci https://idr-ci.openmicroscopy.org"


### PR DESCRIPTION
Pass `-e @var-overrides/omero-ci-build.yml` to the `ansibile-playbook` deployment script to upgrade to a idr-ci build

--depends-on https://github.com/openmicroscopy/prod-playbooks/pull/28
  