### PR TITLE
Add fluentd centralised logging (part 1)

### DIFF
--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -41,6 +41,21 @@
 
 
 ###########################################################################
+# Send to Elasticsearch
+###########################################################################
+
+<label @ELASTICSEARCH>
+  <match **>
+    @type elasticsearch
+    logstash_format true
+    host "{{ fluentd_elasticsearch_host }}"
+    port 9200
+    flush_interval 5s
+  </match>
+</label>
+
+
+###########################################################################
 # nginx-proxy
 ###########################################################################
 
@@ -50,6 +65,10 @@
   <store>
     @type relabel
     @label @STORE_LOGS
+  </store>
+  <store>
+    @type relabel
+    @label @ELASTICSEARCH
   </store>
   <store>
     @type relabel
@@ -101,6 +120,10 @@
   <store>
     @type relabel
     @label @STORE_LOGS
+  </store>
+  <store>
+    @type relabel
+    @label @ELASTICSEARCH
   </store>
   <store>
     @type relabel

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -144,11 +144,7 @@
     </regexp>
     <exclude>
       key message
-      pattern ^Failed during repository takeover
-    </exclude>
-    <exclude>
-      key message
-      pattern ^Method interface .+ invocation took
+      pattern ^(Failed during repository takeover|Method interface .+ invocation took)
     </exclude>
   </filter>
 

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -1,0 +1,147 @@
+###########################################################################
+# Receive TCP logs.
+###########################################################################
+
+# TODO: Secure with client/server SSL certs
+<source>
+  @type forward
+  @id   input1
+  port  24224
+# I can't get this to work
+#  <security>
+#    self_hostname {{ fluentd_server_name }}
+#    shared_key {{ fluentd_shared_key }}
+#  </security>
+</source>
+
+# For debugging only
+<filter **>
+  @type stdout
+</filter>
+
+
+###########################################################################
+# Store logs
+# WARNING: OMERO logs will take up a lot of space!
+###########################################################################
+
+<label @STORE_LOGS>
+  <match **>
+    @type file
+    path /data/fluentd/
+    symlink_path /data/fluentd/current.log
+    append true
+    compress gzip
+    <buffer>
+      # Aggregated logs rotated daily
+      timekey 1d
+      timekey_use_utc true
+    </buffer>
+  </match>
+</label>
+
+
+###########################################################################
+# nginx-proxy
+###########################################################################
+
+# In future more log routes can be added
+<match nginx.**>
+  @type copy
+  <store>
+    @type relabel
+    @label @STORE_LOGS
+  </store>
+  <store>
+    @type relabel
+    @label @NGINX_NOTIFICATION
+  </store>
+</match>
+
+# Notify 5XX and all error logs
+<label @NGINX_NOTIFICATION>
+  <filter nginx.access>
+    @type grep
+    <regexp>
+      key code
+      pattern ^5\d\d$
+    </regexp>
+  </filter>
+  <filter nginx.access>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      message ${record.to_json}
+    </record>
+  </filter>
+
+  <match nginx.*>
+    @type slack
+    token "{{ fluentd_slack_token }}"
+    username fluentd-nginx
+    icon_emoji :warning:
+    channel "{{ fluentd_slack_channel }}"
+    message ":warning: *%s* %s _%s_ @here
+```
+%s
+```
+"
+    message_keys tag,hostname,time,message
+    flush_interval 5s
+  </match>
+</label>
+
+
+###########################################################################
+# omero
+###########################################################################
+
+# In future more log routes can be added
+<match omero.**>
+  @type copy
+  <store>
+    @type relabel
+    @label @STORE_LOGS
+  </store>
+  <store>
+    @type relabel
+    @label @OMERO_NOTIFICATION
+  </store>
+</match>
+
+# Send slack notifications for error and critical
+<label @OMERO_NOTIFICATION>
+  <filter omero.**>
+    @type grep
+    <regexp>
+      key level
+      pattern ^(error|critical)
+    </regexp>
+    # Could also filter by message content
+  </filter>
+
+  <filter omero.**>
+    @type record_transformer
+    enable_ruby
+    <record>
+      # Limit message length
+      message "${record['message'][0, 1024] + (record['message'].length > 1024 ? ' ...' : '')}"
+    </record>
+  </filter>
+
+  <match omero.**>
+    @type slack
+    token "{{ fluentd_slack_token }}"
+    username fluentd-omero
+    icon_emoji :warning:
+    channel "{{ fluentd_slack_channel }}"
+    message ":warning: *%s* %s %s @here
+```
+%s
+```
+"
+    message_keys tag,hostname,time,message
+    time_format %F %T.%L
+    flush_interval 5s
+  </match>
+</label>

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -15,9 +15,9 @@
 </source>
 
 # For debugging only
-<filter **>
-  @type stdout
-</filter>
+#<filter **>
+#  @type stdout
+#</filter>
 
 
 ###########################################################################
@@ -110,6 +110,7 @@
 </match>
 
 # Send slack notifications for error and critical
+# Exclude known errors
 <label @OMERO_NOTIFICATION>
   <filter omero.**>
     @type grep
@@ -117,7 +118,10 @@
       key level
       pattern ^(error|critical)
     </regexp>
-    # Could also filter by message content
+    <exclude>
+      key message
+      pattern ^Failed during repository takeover
+    </exclude>
   </filter>
 
   <filter omero.**>

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -146,6 +146,10 @@
       key message
       pattern ^Failed during repository takeover
     </exclude>
+    <exclude>
+      key message
+      pattern ^Method interface .+ invocation took
+    </exclude>
   </filter>
 
   <filter omero.**>

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -50,7 +50,9 @@
     logstash_format true
     host "{{ fluentd_elasticsearch_host }}"
     port 9200
-    flush_interval 5s
+    include_tag_key true
+    tag_key @log_name
+    flush_interval 10s
   </match>
 </label>
 

--- a/ansible/files/fluentd-server/fluent.conf.j2
+++ b/ansible/files/fluentd-server/fluent.conf.j2
@@ -7,11 +7,10 @@
   @type forward
   @id   input1
   port  24224
-# I can't get this to work
-#  <security>
-#    self_hostname {{ fluentd_server_name }}
-#    shared_key {{ fluentd_shared_key }}
-#  </security>
+  <security>
+    self_hostname {{ ansible_hostname }}
+    shared_key {{ fluentd_shared_key }}
+  </security>
 </source>
 
 # For debugging only
@@ -28,7 +27,7 @@
 <label @STORE_LOGS>
   <match **>
     @type file
-    path /data/fluentd/
+    path /data/fluentd/aggregated
     symlink_path /data/fluentd/current.log
     append true
     compress gzip

--- a/ansible/files/fluentd/forward-conf.j2
+++ b/ansible/files/fluentd/forward-conf.j2
@@ -3,10 +3,6 @@
 # TODO: Add multiple central servers for HA
 
 <label @FORWARD>
-  <filter **>
-    @type stdout
-  </filter>
-
   <match **>
     @type forward
     send_timeout 60s

--- a/ansible/files/fluentd/forward-conf.j2
+++ b/ansible/files/fluentd/forward-conf.j2
@@ -1,0 +1,33 @@
+# Forward all logs labelled FORWARD to a central server
+# https://docs.fluentd.org/v1.0/articles/out_forward
+# TODO: Add multiple central servers for HA
+
+<label @FORWARD>
+  <filter **>
+    @type stdout
+  </filter>
+
+  <match **>
+    @type forward
+    send_timeout 60s
+    recover_wait 10s
+    heartbeat_interval 1s
+    phi_threshold 16
+    hard_timeout 60s
+
+    <server>
+      name {{ fluentd_server_name }}
+      host {{ fluentd_server_address }}
+# I can't get this to work
+#      shared_key {{ fluentd_shared_key }}
+      port 24224
+      weight 60
+    </server>
+
+    # Causes a warning: secondary type should be same with primary one
+    <secondary>
+      @type file
+      path /var/log/td-agent/forward-failed.log
+    </secondary>
+  </match>
+</label>

--- a/ansible/files/fluentd/forward-conf.j2
+++ b/ansible/files/fluentd/forward-conf.j2
@@ -3,6 +3,14 @@
 # TODO: Add multiple central servers for HA
 
 <label @FORWARD>
+  # Add hostname to all records
+  <filter **>
+    @type record_transformer
+    <record>
+      hostname "#{Socket.gethostname[/^[^.]+/]}"
+    </record>
+  </filter>
+
   <match **>
     @type forward
     send_timeout 60s
@@ -12,13 +20,15 @@
     hard_timeout 60s
 
     <server>
-      name {{ fluentd_server_name }}
       host {{ fluentd_server_address }}
-# I can't get this to work
-#      shared_key {{ fluentd_shared_key }}
       port 24224
       weight 60
     </server>
+
+    <security>
+      self_hostname {{ ansible_hostname }}
+      shared_key {{ fluentd_shared_key }}
+    </security>
 
     # Causes a warning: secondary type should be same with primary one
     <secondary>

--- a/ansible/files/fluentd/nginx-proxy-conf.j2
+++ b/ansible/files/fluentd/nginx-proxy-conf.j2
@@ -1,0 +1,72 @@
+# Slack alerts for nginx access.log 5XX and all error.log
+
+# Log format: main_timed_cache_upstream
+# https://github.com/openmicroscopy/ansible-role-nginx-proxy/blob/1.6.0/templates/nginx-conf.j2#L39
+<source>
+  @type tail
+  path /var/log/nginx/access.log
+  pos_file /var/log/td-agent/nginx-access.log.pos
+  tag nginx.access
+
+  format /^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")? "(?<forwarded>[^\"]*)" (?<reqtime>[^ ]*) (?<cachestatus>[^ ]*) (?<upstream>[^ ]*)/
+  time_format %d/%b/%Y:%H:%M:%S %z
+</source>
+
+# In some situations error.log may be multiline
+<source>
+  @type tail
+  path /var/log/nginx/error.log
+  pos_file /var/log/td-agent/nginx-error.log.pos
+  tag nginx.error
+
+  format multiline
+  format_firstline /^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] (?<pid>\d+).(?<tid>\d+): /
+  format1 /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)/
+  multiline_flush_interval 3s
+</source>
+
+# Add hostname to all records
+<filter nginx.*>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+  </record>
+</filter>
+
+<match nginx.*>
+  @type relabel
+  @label @NGINX_NOTIFICATION
+</match>
+
+# Notify 5XX and all error logs
+<label @NGINX_NOTIFICATION>
+  <filter nginx.access>
+    @type grep
+    <regexp>
+      key code
+      pattern ^5\d\d$
+    </regexp>
+  </filter>
+  <filter nginx.access>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      message ${record.to_json}
+    </record>
+  </filter>
+
+  <match nginx.*>
+    @type slack
+    token "#{ENV['SLACK_TOKEN']}"
+    username fluentd-nginx
+    icon_emoji :warning:
+    channel "#{{ fluentd_nginx_slack_channel }}"
+    message ":warning: *%s* %s _%s_ @here
+```
+%s
+```
+"
+    message_keys tag,hostname,time,message
+    flush_interval 5s
+  </match>
+</label>

--- a/ansible/files/fluentd/nginx-proxy.conf
+++ b/ansible/files/fluentd/nginx-proxy.conf
@@ -25,14 +25,6 @@
   multiline_flush_interval 3s
 </source>
 
-# Add hostname to all records
-<filter nginx.*>
-  @type record_transformer
-  <record>
-    hostname "#{Socket.gethostname}"
-  </record>
-</filter>
-
 <match nginx.*>
   @type relabel
   @label @FORWARD

--- a/ansible/files/fluentd/nginx-proxy.conf
+++ b/ansible/files/fluentd/nginx-proxy.conf
@@ -35,38 +35,5 @@
 
 <match nginx.*>
   @type relabel
-  @label @NGINX_NOTIFICATION
+  @label @FORWARD
 </match>
-
-# Notify 5XX and all error logs
-<label @NGINX_NOTIFICATION>
-  <filter nginx.access>
-    @type grep
-    <regexp>
-      key code
-      pattern ^5\d\d$
-    </regexp>
-  </filter>
-  <filter nginx.access>
-    @type record_transformer
-    enable_ruby true
-    <record>
-      message ${record.to_json}
-    </record>
-  </filter>
-
-  <match nginx.*>
-    @type slack
-    token "#{ENV['SLACK_TOKEN']}"
-    username fluentd-nginx
-    icon_emoji :warning:
-    channel "#{{ fluentd_nginx_slack_channel }}"
-    message ":warning: *%s* %s _%s_ @here
-```
-%s
-```
-"
-    message_keys tag,hostname,time,message
-    flush_interval 5s
-  </match>
-</label>

--- a/ansible/files/fluentd/omero.conf
+++ b/ansible/files/fluentd/omero.conf
@@ -17,14 +17,16 @@
 
 # TODO: Add source for master.out master.err
 
-# Add source hostname and file, standardise level text:
-# info, warn, error, critical
+# Add filename
+# Standardise level: info, warn, error, critical
+# Truncate message at 4KB
 <filter raw.omero.**>
   @type record_transformer
   enable_ruby
   <record>
     file ${tag_parts[-2]}.${tag_parts[-1]}
     level "${record['level'].downcase.gsub(/^inf.*/i, 'info').downcase.gsub(/^war.*/i, 'warn').gsub(/^err.*/i, 'error').gsub(/^cri.*/i, 'critical').gsub(/^fat.*/i, 'critical')}"
+    message "${record['message'][0, 4096] + (record['message'].length > 4096 ? ' ...' : '')}"
   </record>
 </filter>
 

--- a/ansible/files/fluentd/omero.conf
+++ b/ansible/files/fluentd/omero.conf
@@ -23,7 +23,6 @@
   @type record_transformer
   enable_ruby
   <record>
-    hostname "#{Socket.gethostname}"
     file ${tag_parts[-2]}.${tag_parts[-1]}
     level "${record['level'].downcase.gsub(/^inf.*/i, 'info').downcase.gsub(/^war.*/i, 'warn').gsub(/^err.*/i, 'error').gsub(/^cri.*/i, 'critical').gsub(/^fat.*/i, 'critical')}"
   </record>

--- a/ansible/files/fluentd/omero.conf
+++ b/ansible/files/fluentd/omero.conf
@@ -49,11 +49,6 @@
   </rule>
 </match>
 
-# For debugging only
-<filter omero.**>
-  @type stdout
-</filter>
-
 # Discard debug logs
 <filter omero.**>
   @type grep

--- a/ansible/files/fluentd/omero.conf
+++ b/ansible/files/fluentd/omero.conf
@@ -1,10 +1,13 @@
 # http://fluentular.herokuapp.com/
 
+
+######################################################################
 # Parse multiline log messages of the form
 # YYYY-MM-DD hh:mm:ss.mss level [class] (thread) ...
+######################################################################
 <source>
   @type tail
-  path /opt/omero/server/OMERO.server/var/log/Blitz-0.log,/opt/omero/server/OMERO.server/var/log/DropBox.log,/opt/omero/server/OMERO.server/var/log/FileServer.log,/opt/omero/server/OMERO.server/var/log/Indexer-0.log,/opt/omero/server/OMERO.server/var/log/MonitorServer.log,/opt/omero/server/OMERO.server/var/log/PixelData-0.log,/opt/omero/server/OMERO.server/var/log/Processor-0.log,/opt/omero/server/OMERO.server/var/log/Tables-0.log,/opt/omero/web/OMERO.web/var/log/OMEROweb.log
+  path /opt/omero/server/OMERO.server/var/log/*.log,/opt/omero/web/OMERO.web/var/log/*.log
 
   pos_file /var/log/td-agent/omero.log.pos
   tag raw.omero.*
@@ -13,9 +16,8 @@
   format_firstline /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+\w+/
   format1 /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s*(?<level>\w+)\s*\[\s*(?<class>[^\]]+)\]\s*\((?<thread>[^\)]+)\)\s*(?<message>.*)/
   time_format %Y-%m-%d %H:%M:%S,%L
+  multiline_flush_interval 5s
 </source>
-
-# TODO: Add source for master.out master.err
 
 # Add filename
 # Standardise level: info, warn, error, critical
@@ -40,6 +42,59 @@
   </rule>
 </match>
 
+
+######################################################################
+# *.{err,out} logs follow a mix of formats, a datetime is not
+# guaranteed
+# Assume any line that doesn't start with whitespace is the start of a
+# multiline log message
+######################################################################
+<source>
+  @type tail
+  path /opt/omero/server/OMERO.server/var/log/*.err,/opt/omero/server/OMERO.server/var/log/*.out
+
+  pos_file /var/log/td-agent/omero.node.pos
+  tag raw.omeronode.*
+
+  format multiline
+  format_firstline /^\S/
+  format1 /^(?<message>.+)/
+  multiline_flush_interval 5s
+</source>
+
+# Add filename
+# Add level: out:info, err:error
+# Truncate message at 4KB
+<filter raw.omeronode.**>
+  @type record_transformer
+  enable_ruby
+  <record>
+    file ${tag_parts[-2]}.${tag_parts[-1]}
+    level "${tag_parts[-1].downcase.gsub(/^out.*/i, 'info').downcase.gsub(/^err.*/i, 'error')}"
+    message "${record['message'][0, 4096] + (record['message'].length > 4096 ? ' ...' : '')}"
+  </record>
+</filter>
+
+# Add server node to tag
+<match raw.omeronode.**>
+  @type rewrite_tag_filter
+  <rule>
+    key file
+    pattern ^(\w+)\.\w+$
+    tag raw1.omero.$1
+  </rule>
+</match>
+
+
+######################################################################
+# Common OMERO log processing
+######################################################################
+
+# For debugging only
+#<filter **>
+#  @type stdout
+#</filter>
+
 # Add log level to tag
 <match raw1.omero.**>
   @type rewrite_tag_filter
@@ -55,7 +110,7 @@
   @type grep
   <regexp>
     key level
-    pattern ^(info|warn|error|fatal)
+    pattern ^(info|warn|error|critical)
   </regexp>
 </filter>
 

--- a/ansible/files/fluentd/omero.conf
+++ b/ansible/files/fluentd/omero.conf
@@ -1,0 +1,69 @@
+# http://fluentular.herokuapp.com/
+
+# Parse multiline log messages of the form
+# YYYY-MM-DD hh:mm:ss.mss level [class] (thread) ...
+<source>
+  @type tail
+  path /opt/omero/server/OMERO.server/var/log/Blitz-0.log,/opt/omero/server/OMERO.server/var/log/DropBox.log,/opt/omero/server/OMERO.server/var/log/FileServer.log,/opt/omero/server/OMERO.server/var/log/Indexer-0.log,/opt/omero/server/OMERO.server/var/log/MonitorServer.log,/opt/omero/server/OMERO.server/var/log/PixelData-0.log,/opt/omero/server/OMERO.server/var/log/Processor-0.log,/opt/omero/server/OMERO.server/var/log/Tables-0.log,/opt/omero/web/OMERO.web/var/log/OMEROweb.log
+
+  pos_file /var/log/td-agent/omero.log.pos
+  tag raw.omero.*
+
+  format multiline
+  format_firstline /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+\w+/
+  format1 /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s*(?<level>\w+)\s*\[\s*(?<class>[^\]]+)\]\s*\((?<thread>[^\)]+)\)\s*(?<message>.*)/
+  time_format %Y-%m-%d %H:%M:%S,%L
+</source>
+
+# TODO: Add source for master.out master.err
+
+# Add source hostname and file, standardise level text:
+# info, warn, error, critical
+<filter raw.omero.**>
+  @type record_transformer
+  enable_ruby
+  <record>
+    hostname "#{Socket.gethostname}"
+    file ${tag_parts[-2]}.${tag_parts[-1]}
+    level "${record['level'].downcase.gsub(/^inf.*/i, 'info').downcase.gsub(/^war.*/i, 'warn').gsub(/^err.*/i, 'error').gsub(/^cri.*/i, 'critical').gsub(/^fat.*/i, 'critical')}"
+  </record>
+</filter>
+
+# Add server component to tag
+<match raw.omero.**>
+  @type rewrite_tag_filter
+  <rule>
+    key file
+    pattern ^(\w+)(-\w+)?\.log$
+    tag raw1.omero.$1
+  </rule>
+</match>
+
+# Add log level to tag
+<match raw1.omero.**>
+  @type rewrite_tag_filter
+  <rule>
+    key level
+    pattern (.+)
+    tag omero.${tag_parts[2]}.$1
+  </rule>
+</match>
+
+# For debugging only
+<filter omero.**>
+  @type stdout
+</filter>
+
+# Discard debug logs
+<filter omero.**>
+  @type grep
+  <regexp>
+    key level
+    pattern ^(info|warn|error|fatal)
+  </regexp>
+</filter>
+
+<match omero.**>
+  @type relabel
+  @label @FORWARD
+</match>

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -22,6 +22,13 @@ ice_python_wheel: https://github.com/openmicroscopy/zeroc-ice-py-centos7/release
 # This is needed to ensure the client version matches the server
 postgresql_version: "9.6"
 
+
+######################################################################
+# openmicroscopy.fluentd vars
+fluentd_source_configs:
+- files/fluentd/omero.conf
+
+
 ######################################################################
 # openmicroscopy.omero-server role vars
 

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -324,3 +324,11 @@ idr_openmicroscopy_org_config:
   idr_deployment_version: "{{ idr_environment | default('idr') }}"
 #  idr_deployment_date: "DD MMM YYYY"
 #  idr_deployment_notes: "https://example.org/release-notes"
+
+
+######################################################################
+# openmicroscopy.fluentd vars
+fluentd_groups:
+- adm
+fluentd_source_configs:
+- files/fluentd/nginx-proxy.conf

--- a/ansible/idr-09-monitoring.yml
+++ b/ansible/idr-09-monitoring.yml
@@ -4,3 +4,4 @@
 - include: management.yml
 - include: management-prometheus.yml
 - include: management-grafana.yml
+- include: management-fluentd.yml

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -53,7 +53,6 @@
       - /data/fluentd:/data/fluentd
 
   vars:
-    fluentd_server_name: "{{ ansible_hostname }}"
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
     fluentd_slack_channel: "idr-notify-{{ idr_environment | default('idr') }}"
@@ -67,14 +66,17 @@
   roles:
   - role: openmicroscopy.fluentd
 
-  tasks:
-
   # TODO: Ideally we'd use the `validate:` option to check these config
-  # files, but it's not possible to validate only a fragment
-  # If there's an error in these files you will ahve to manually delete
-  # them since the previous role will attempt (and fail) to start
-  # td-agent, so we'll never reach the point at which config fixes
-  # are applied
+  # files, but it's not possible to validate only a fragment.
+  # Instead we need to create these files before applying the role
+  pre_tasks:
+
+  - name: Create fluentd conf.d
+    become: yes
+    file:
+      path: /etc/td-agent/conf.d
+      state: directory
+
   - name: Configure fluentd forwarding
     become: yes
     template:
@@ -95,6 +97,5 @@
     - restart fluentd
 
   vars:
-    fluentd_server_name: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]].ansible_hostname }}"
     fluentd_server_address: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -37,6 +37,7 @@
     docker_container:
       image: manics/fluentd-idr
       name: fluentd
+      cleanup: True
       state: stopped
     when: fluent_conf_status | changed
 
@@ -55,6 +56,7 @@
     docker_container:
       image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
       name: elasticsearch
+      cleanup: True
       env:
         discovery.type: single-node
         ES_JAVA_OPTS: "-Xmx4096m"
@@ -71,6 +73,7 @@
     docker_container:
       image: manics/fluentd-idr
       name: fluentd
+      cleanup: True
       links:
       - "elasticsearch:elasticsearch"
       published_ports:
@@ -87,6 +90,7 @@
     docker_container:
       image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
       name: kibana
+      cleanup: True
       links:
       # This matches the default kibana config:
       - "elasticsearch:elasticsearch"

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -1,0 +1,32 @@
+# Fluentd log handling
+
+- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
+
+  roles:
+  - role: openmicroscopy.fluentd
+    fluentd_plugins:
+      - fluent-plugin-slack
+    fluentd_env:
+      SLACK_TOKEN: "{{ idr_secret_management_slack_token | default(None) }}"
+
+  tasks:
+
+  - name: copy nginx fluentd config
+    become: yes
+    template:
+      src: files/fluentd/nginx-proxy-conf.j2
+      dest: /etc/td-agent/conf.d/nginx-proxy.conf
+    notify:
+    - restart fluentd
+
+  - name: add fluentd user to adm group
+    become: yes
+    user:
+      name: td-agent
+      append: yes
+      groups: adm
+    notify:
+    - restart fluentd
+
+  vars:
+    fluentd_nginx_slack_channel: idr-notify-{{ idr_environment | default('idr') }}

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -134,6 +134,7 @@
     become: yes
     file:
       path: /etc/td-agent/conf.d
+      recurse: yes
       state: directory
 
   - name: Configure fluentd forwarding

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -1,32 +1,100 @@
 # Fluentd log handling
 
-- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
-
-  roles:
-  - role: openmicroscopy.fluentd
-    fluentd_plugins:
-      - fluent-plugin-slack
-    fluentd_env:
-      SLACK_TOKEN: "{{ idr_secret_management_slack_token | default(None) }}"
+# This assumes docker has already been installed
+# (by management-prometheus.yml)
+- hosts: "{{ idr_environment | default('idr') }}-management-hosts"
 
   tasks:
 
-  - name: copy nginx fluentd config
+  - name: Create fluentd server configuration directory
+    become: yes
+    file:
+      path: /etc/fluentd
+      recurse: yes
+      state: directory
+
+  - name: Create fluentd aggregated logs directory
+    become: yes
+    file:
+      path: /data/fluentd
+      recurse: yes
+      state: directory
+      # User id in fluentd Docker image
+      owner: 1000
+      group: 1000
+
+  - name: Copy fluentd server configuration files
     become: yes
     template:
-      src: files/fluentd/nginx-proxy-conf.j2
-      dest: /etc/td-agent/conf.d/nginx-proxy.conf
+      src: files/fluentd-server/fluent.conf.j2
+      dest: /etc/fluentd/fluent.conf
+    register: fluent_conf_status
+
+  - name: Stop docker fluentd if config changed
+    become: yes
+    docker_container:
+      image: manics/fluentd-idr
+      name: fluentd
+      state: stopped
+    when: fluent_conf_status | changed
+
+  - name: Run docker fluentd
+    become: yes
+    docker_container:
+      image: manics/fluentd-idr
+      name: fluentd
+      published_ports:
+      - "24224:24224/udp"
+      - "24224:24224"
+      state: started
+      restart_policy: always
+      volumes:
+      - /etc/fluentd/fluent.conf:/fluentd/etc/fluent.conf:ro
+      - /data/fluentd:/data/fluentd
+
+  vars:
+    fluentd_server_name: "{{ ansible_hostname }}"
+    fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"
+    fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
+    fluentd_slack_channel: "idr-notify-{{ idr_environment | default('idr') }}"
+
+
+
+- hosts: >
+    {{ idr_environment | default('idr') }}-proxy-hosts
+    {{ idr_environment | default('idr') }}-omero-hosts
+
+  roles:
+  - role: openmicroscopy.fluentd
+
+  tasks:
+
+  # TODO: Ideally we'd use the `validate:` option to check these config
+  # files, but it's not possible to validate only a fragment
+  # If there's an error in these files you will ahve to manually delete
+  # them since the previous role will attempt (and fail) to start
+  # td-agent, so we'll never reach the point at which config fixes
+  # are applied
+  - name: Configure fluentd forwarding
+    become: yes
+    template:
+      src: files/fluentd/forward-conf.j2
+      dest: /etc/td-agent/conf.d/forward.conf
     notify:
     - restart fluentd
 
-  - name: add fluentd user to adm group
+  - name: Copy fluentd configuration
     become: yes
-    user:
-      name: td-agent
-      append: yes
-      groups: adm
+    copy:
+      src: "{{ item }}"
+      dest: "/etc/td-agent/conf.d/{{ item | basename }}"
+    with_items:
+    # These are specifc to each host-group
+    - "{{ fluentd_source_configs }}"
     notify:
     - restart fluentd
 
   vars:
-    fluentd_nginx_slack_channel: idr-notify-{{ idr_environment | default('idr') }}
+    fluentd_server_name: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]].ansible_hostname }}"
+    fluentd_server_address: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
+    fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -1,4 +1,5 @@
 # Fluentd log handling
+# + Elasticsearch + Kibana
 
 # This assumes docker has already been installed
 # (by management-prometheus.yml)
@@ -38,11 +39,38 @@
       state: stopped
     when: fluent_conf_status | changed
 
+  - name: Create elasticsearch directory
+    become: yes
+    file:
+      path: /data/elasticsearch
+      recurse: yes
+      state: directory
+      # User id in elasticsearch Docker image
+      owner: 1000
+      group: 1000
+
+  - name: Run docker elasticsearch
+    become: yes
+    docker_container:
+      image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
+      name: elasticsearch
+      env:
+        discovery.type: single-node
+      published_ports:
+      - "9200:9200"
+      #- "9300:9300"
+      state: started
+      restart_policy: always
+      volumes:
+      - /data/elasticsearch:/usr/share/elasticsearch/data
+
   - name: Run docker fluentd
     become: yes
     docker_container:
       image: manics/fluentd-idr
       name: fluentd
+      links:
+      - "elasticsearch:elasticsearch"
       published_ports:
       - "24224:24224/udp"
       - "24224:24224"
@@ -52,10 +80,24 @@
       - /etc/fluentd/fluent.conf:/fluentd/etc/fluent.conf:ro
       - /data/fluentd:/data/fluentd
 
+  - name: Run docker kibana
+    become: yes
+    docker_container:
+      image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
+      name: kibana
+      links:
+      # This matches the default kibana config:
+      - "elasticsearch:elasticsearch"
+      published_ports:
+      - "5601:5601"
+      state: started
+      restart_policy: always
+
   vars:
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
     fluentd_slack_channel: "idr-notify-{{ idr_environment | default('idr') }}"
+    fluentd_elasticsearch_host: elasticsearch
 
 
 

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -15,15 +15,21 @@
       recurse: yes
       state: directory
 
+  - name: Create data top level directory
+    become: yes
+    file:
+      path: /data
+      state: directory
+      owner: root
+      group: root
+
   - name: Create fluentd aggregated logs directory
     become: yes
     file:
       path: /data/fluentd
-      recurse: yes
       state: directory
-      # User id in fluentd Docker image
-      owner: 1000
-      group: 1000
+      owner: "{{ fluentd_uid }}"
+      group: "{{ fluentd_uid }}"
 
   - name: Copy fluentd server configuration files
     become: yes
@@ -32,34 +38,32 @@
       dest: /etc/fluentd/fluent.conf
     register: fluent_conf_status
 
-  - name: Stop docker fluentd if config changed
-    become: yes
-    docker_container:
-      image: manics/fluentd-idr
-      name: fluentd
-      cleanup: True
-      state: stopped
-    when: fluent_conf_status | changed
-
   - name: Create elasticsearch directory
     become: yes
     file:
       path: /data/elasticsearch
-      recurse: yes
       state: directory
       # User id in elasticsearch Docker image
       owner: 1000
       group: 1000
 
+  - name: Create docker network
+    become: yes
+    docker_network:
+      name: fluent-es-kb
+      state: present
+
   - name: Run docker elasticsearch
     become: yes
     docker_container:
-      image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
+      image: "{{ elasticsearch_docker_image }}"
       name: elasticsearch
       cleanup: True
       env:
         discovery.type: single-node
         ES_JAVA_OPTS: "-Xmx4096m"
+      networks:
+      - name: fluent-es-kb
       published_ports:
       - "9200:9200"
       #- "9300:9300"
@@ -71,14 +75,17 @@
   - name: Run docker fluentd
     become: yes
     docker_container:
-      image: manics/fluentd-idr
+      image: "{{ fluentd_docker_image }}"
       name: fluentd
       cleanup: True
-      links:
-      - "elasticsearch:elasticsearch"
+      env:
+        FLUENT_UID: "{{ fluentd_uid }}"
+      networks:
+      - name: fluent-es-kb
       published_ports:
       - "24224:24224/udp"
       - "24224:24224"
+      restart: "{{ fluent_conf_status | changed }}"
       state: started
       restart_policy: always
       volumes:
@@ -88,12 +95,11 @@
   - name: Run docker kibana
     become: yes
     docker_container:
-      image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
+      image: "{{ kibana_docker_image }}"
       name: kibana
       cleanup: True
-      links:
-      # This matches the default kibana config:
-      - "elasticsearch:elasticsearch"
+      networks:
+      - name: fluent-es-kb
       published_ports:
       - "5601:5601"
       state: started
@@ -104,6 +110,11 @@
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
     fluentd_slack_channel: "idr-notify-{{ idr_environment | default('idr') }}"
     fluentd_elasticsearch_host: elasticsearch
+    fluentd_uid: 1010
+    elasticsearch_docker_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
+    fluentd_docker_image: "openmicroscopy/fluentd:0.1.0"
+    #fluentd_docker_image: "manics/fluentd-idr"
+    kibana_docker_image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
 
 
 

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -1,5 +1,6 @@
 # Fluentd log handling
-# + Elasticsearch + Kibana
+# + Elasticsearch + Kibana in Docker
+# https://www.fluentd.org/guides/recipes/elasticsearch-and-s3
 
 # This assumes docker has already been installed
 # (by management-prometheus.yml)
@@ -56,6 +57,7 @@
       name: elasticsearch
       env:
         discovery.type: single-node
+        ES_JAVA_OPTS: "-Xmx4096m"
       published_ports:
       - "9200:9200"
       #- "9300:9300"

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -105,6 +105,20 @@
       state: started
       restart_policy: always
 
+  - name: Run elasticsearch curator
+    become: yes
+    docker_container:
+      image: "{{ elasticsearch_curator_docker_image }}"
+      name: elasticsearch-curator
+      cleanup: True
+      env:
+        OLDER_THAN_IN_DAYS: "{{ elasticsearch_expire_logs_days }}"
+        INTERVAL_IN_HOURS: 24
+      networks:
+      - name: fluent-es-kb
+      state: started
+      restart_policy: always
+
   vars:
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
@@ -112,8 +126,9 @@
     fluentd_elasticsearch_host: elasticsearch
     fluentd_uid: 1010
     elasticsearch_docker_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
+    elasticsearch_curator_docker_image: "openmicroscopy/elasticsearch-curator:5.4.1"
+    elasticsearch_expire_logs_days: 14
     fluentd_docker_image: "openmicroscopy/fluentd:0.1.0"
-    #fluentd_docker_image: "manics/fluentd-idr"
     kibana_docker_image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
 
 

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -137,13 +137,17 @@
     {{ idr_environment | default('idr') }}-proxy-hosts
     {{ idr_environment | default('idr') }}-omero-hosts
 
-  roles:
-  - role: openmicroscopy.fluentd
-
   # TODO: Ideally we'd use the `validate:` option to check these config
   # files, but it's not possible to validate only a fragment.
   # Instead we need to create these files before applying the role
+  # However, we can only trigger the restart handler if the agent is
+  # already installed.
   pre_tasks:
+
+  - name: Check if td-agent already installed
+    stat:
+      path: /etc/init.d/td-agent
+    register: _td_agent_st
 
   - name: Create fluentd conf.d
     become: yes
@@ -158,7 +162,7 @@
       src: files/fluentd/forward-conf.j2
       dest: /etc/td-agent/conf.d/forward.conf
     notify:
-    - restart fluentd
+    - restart fluentd if installed
 
   - name: Copy fluentd configuration
     become: yes
@@ -169,7 +173,19 @@
     # These are specifc to each host-group
     - "{{ fluentd_source_configs }}"
     notify:
-    - restart fluentd
+    - restart fluentd if installed
+
+  handlers:
+  - name: restart fluentd if installed
+    become: yes
+    systemd:
+      daemon_reload: yes
+      name: td-agent
+      state: restarted
+    when: _td_agent_st.stat.exists
+
+  roles:
+  - role: openmicroscopy.fluentd
 
   vars:
     fluentd_server_address: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,6 +24,10 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
+- name: openmicroscopy.fluentd
+  src: https://github.com/manics/ansible-role-fluentd/archive/0.2.0.tar.gz
+  version: 0.2.0
+
 - src: openmicroscopy.haproxy
   version: 2.1.0-m1
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,10 +24,6 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- name: openmicroscopy.fluentd
-  src: https://github.com/manics/ansible-role-fluentd/archive/0.2.1.tar.gz
-  version: 0.2.1
-
 - src: openmicroscopy.haproxy
   version: 2.1.0-m1
 
@@ -168,6 +164,10 @@
 - name: openmicroscopy.docker-slack-notifier
   src: https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/archive/0.0.2.tar.gz
   version: 0.0.2
+
+- name: openmicroscopy.fluentd
+  src: https://github.com/openmicroscopy/ansible-role-fluentd/archive/0.2.1.tar.gz
+  version: 0.2.1
 
 - name: openmicroscopy.prometheus
   src: https://github.com/openmicroscopy/ansible-role-prometheus/archive/0.2.0.tar.gz

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -25,8 +25,8 @@
   version: 1.0.0
 
 - name: openmicroscopy.fluentd
-  src: https://github.com/manics/ansible-role-fluentd/archive/0.2.0.tar.gz
-  version: 0.2.0
+  src: https://github.com/manics/ansible-role-fluentd/archive/0.2.1.tar.gz
+  version: 0.2.1
 
 - src: openmicroscopy.haproxy
   version: 2.1.0-m1


### PR DESCRIPTION
~Currently alerts are sent from the monitored node, eventually this will be changed so logs are aggregated and alerts are sent from the central management node.~

Initial work on centralised logging and alerting:
- Central fluentd server for receiving logs and sending Slack alerts
- Agent on idr-proxy to transfer nginx `*.log`
- Agent on idr-omero* to transfer OMERO.server and OMERO.web `*.log` `*.err` `*.out`

Caveats:
- An obvious extension of this work is to process other logs such as haproxy
- Elasticsearch and Kibana are currently unauthenticated (anyone inside the IDR network can access and modify them)
- Elasticsearch configuration (e.g. dashboards) will not be saved between deployments
- In future we could consider whether the configs can be reused outside the IDR, though this can be left until we decide this is worth continuing, and we have other production uses.
- If we decide this is stable for the IDR we can get rid of `omero-logmonitor`

Current slack alerts:
- Everything in `nginx/error_log` (this will need tuning since jupyter causes several spurious logs)
- All `5XX` logs in `nginx/access_log`
- OMERO.{server,web}/var/log/*.log with level `ERROR`, with the exception of logs matching `^(Failed during repository takeover|Method interface .+ invocation took)`
- Everything in `master.err`

To access Kibana (UI to Elasticsearch, which stores logs from Fluentd) tunnel http://IDR-managment:5601/

Related:
- This started off as work on https://trello.com/c/xM75Wput/27-nginx-error-log-parsing but it was relatively straightforward to extend this to centralised logging, especially given various inter-service bugs in the IDR which would benefit from a combined log viewer.

Todo:
- [x] Transfer https://github.com/manics/fluentd-docker
- [x] Transfer https://github.com/manics/ansible-role-fluentd