### PR TITLE
Exclude docker* kube* from yum upgrades (IDR-0.4.5)

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,3 @@
+upgrade_distpackages_excludes:
+- "docker*"
+- "kube*"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -124,7 +124,6 @@
   version: 1.0.0
 
 - name: openmicroscopy.upgrade-distpackages
-  src: https://github.com/manics/ansible-role-upgrade-distpackages/archive/excludes.tar.gz
   version: 1.1.0
 
 - src: openmicroscopy.versioncontrol-utils

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -123,7 +123,7 @@
 - src: openmicroscopy.sudoers
   version: 1.0.0
 
-- name: openmicroscopy.upgrade-distpackages
+- src: openmicroscopy.upgrade-distpackages
   version: 1.1.0
 
 - src: openmicroscopy.versioncontrol-utils

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -123,8 +123,9 @@
 - src: openmicroscopy.sudoers
   version: 1.0.0
 
-- src: openmicroscopy.upgrade-distpackages
-  version: 1.0.1
+- name: openmicroscopy.upgrade-distpackages
+  src: https://github.com/manics/ansible-role-upgrade-distpackages/archive/excludes.tar.gz
+  version: 1.1.0
 
 - src: openmicroscopy.versioncontrol-utils
   version: 1.0.0


### PR DESCRIPTION
During future maintenance we may want to upgrade distro packages. This adds a configuration to prevent `docker*` and `kube*` packages being upgraded. With this in place it _should_ be safe to run all playbooks (against an existing production deployment.

- [x] --depends-on https://github.com/openmicroscopy/ansible-role-upgrade-distpackages/pull/2