### PR TITLE
Final version bumps prior to IDR release

### DIFF
--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -5,4 +5,4 @@ kubernetes_cni_version: 0.5.1-0
 
 idr_prepull_docker_images:
 - "imagedata/jupyterhub-githubauth:0.5.0"
-- "bramalingam/idr_jupyter:idr_jupyter_v06"
+- "imagedata/jupyter-docker:0.6.1"

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -5,4 +5,4 @@ kubernetes_cni_version: 0.5.1-0
 
 idr_prepull_docker_images:
 - "imagedata/jupyterhub-githubauth:0.5.0"
-- "imagedata/jupyter-docker:0.5.0"
+- "imagedata/jupyter-docker:0.6.0"

--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -5,4 +5,4 @@ kubernetes_cni_version: 0.5.1-0
 
 idr_prepull_docker_images:
 - "imagedata/jupyterhub-githubauth:0.5.0"
-- "imagedata/jupyter-docker:0.6.0"
+- "bramalingam/idr_jupyter:idr_jupyter_v06"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.4.5-rc2"
+idr_omero_release: "0.4.5"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -25,7 +25,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.haproxy
-  version: 2.1.0-m1
+  version: 2.1.2
 
 - src: openmicroscopy.hosts-populate
   version: 0.1.1


### PR DESCRIPTION
- Bumps IDR OMERO to 0.4.5 (no change since rc2, drops the suffix)
- Bumps the Jupyter Docker image to 0.6.0 (to be created)