### PR TITLE
Fix host used for rsyncing the Mineotaur data

### DIFF
--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -18,7 +18,7 @@
       default_rsync_mineotaur_url: >-
         rsync://{{
           hostvars[groups[idr_environment |
-            default('idr') + '-omero-hosts'][0]]
+            default('idr') + '-omeroreadwrite-hosts'][0]]
           ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}/mineotaur/idr0001gramlsysgroscreenA/
 


### PR DESCRIPTION
This rsync was adjusted in #77 to prevent timeouts. However, this results in a `Connection refused`  error as only the readwrite hosts are currently set up for the rsync.

This PR adjusts the default rsync URL. 

Should be tested by the deployment of `test46`