### PR TITLE
Use centos username rather than id

### DIFF
--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -22,11 +22,12 @@
           ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}/mineotaur/idr0001gramlsysgroscreenA/
 
-  # Run as UID 1000 since this is required by the Docker container
   # When running externally pull down the IDR data by defining:
   # idr_rsync_mineotaur_url: "rsync://idr.openmicroscopy.org/mineotaur/"
   - name: download mineotaur data
     become: yes
+    # centos user has UID 1000 as required by the mineotaur Docker container
+    # https://hub.docker.com/r/imagedata/mineotaur/
     become_user: centos
     synchronize:
       src: >-

--- a/ansible/idr-mineotaur.yml
+++ b/ansible/idr-mineotaur.yml
@@ -10,7 +10,7 @@
     become: yes
     file:
       path: "/data/mineotaur/idr0001gramlsysgroscreenA"
-      owner: 1000
+      owner: centos
       state: directory
 
   - name: set default rsync mineotaur_url
@@ -27,7 +27,7 @@
   # idr_rsync_mineotaur_url: "rsync://idr.openmicroscopy.org/mineotaur/"
   - name: download mineotaur data
     become: yes
-    become_user: 1000
+    become_user: centos
     synchronize:
       src: >-
         {{


### PR DESCRIPTION
With Ansible 2.4.3.0, this change was necessary to run the playbook. Without
it, the download task fails with an error of type
`sudo: unknown user: 1000\r\nsudo: unable to initialize policy plugin\r\n`