### PR TITLE
K8s idr-omero-public is now a proxy config server (IDR-0.4.6)

### DIFF
--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -4,7 +4,7 @@
 
 # Load hostvars (production OMERO)
 - hosts: >
-    {{ idr_environment | default('idr') }}-omeroreadonly-hosts
+    {{ idr_environment | default('idr') }}-proxy-hosts
 
 
 - hosts: >
@@ -21,28 +21,14 @@
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
 
-  - name: Get omero IP
+  - name: Get internal proxy IP for omero
     set_fact:
-      docker_omeroreadonly_hosts: >-
+      proxy_omeroreadonly_endpoint_addresses: >-
         {{
-          groups[idr_environment | default('idr') + '-omeroreadonly-hosts'] |
+          groups[idr_environment | default('idr') + '-proxy-hosts'] |
           map('extract', hostvars,
             ['ansible_' + (idr_net_iface | default('eth0')), 'ipv4', 'address']) | sort
         }}
-
-  # https://stackoverflow.com/a/35608380
-  # TODO: Find a nicer way to do this instead of a set_fact loop
-  - name: Get omero kubernetes endpoint addresses
-    set_fact:
-      docker_omeroreadonly_endpoint_addresses: >
-        {{ docker_omeroreadonly_endpoint_addresses | default([]) +
-           [{
-             'ip': item
-            }]
-        }}
-    with_items:
-    - "{{ docker_omeroreadonly_hosts }}"
-
 
   roles:
     - role: kubernetes
@@ -115,7 +101,7 @@
     - mineotaur/nfsvolume.yml
     # Requires kubernetes_jupyterhub_config_hash
     - jupyterhub/deployment.yml
-    # Requires docker_omeroreadonly_endpoint_addresses
+    # Requires proxy_omeroreadonly_endpoint_addresses
     - external-omero/external-service.yml
 
 - hosts: >

--- a/ansible/kubernetes-spec/external-omero/external-service.yml
+++ b/ansible/kubernetes-spec/external-omero/external-service.yml
@@ -8,10 +8,10 @@ metadata:
     name: idr-omero-public
 spec:
   ports:
-  - name: omero-secure
+  - name: omero-proxyinfo
     protocol: TCP
-    port: 4064
-    targetPort: 4064
+    port: 80
+    targetPort: 80
   selector: {}
 
 ---
@@ -20,7 +20,10 @@ apiVersion: v1
 metadata:
   name: idr-omero-public
 subsets:
-- addresses: {{ docker_omeroreadonly_endpoint_addresses | sort | to_json }}
+- addresses:
+{% for addr in proxy_omeroreadonly_endpoint_addresses %}
+  - ip: {{ addr }}
+{% endfor %}
   ports:
-  - name: omero-secure
-    port: 4064
+  - name: omero-proxyinfo
+    port: 80


### PR DESCRIPTION
This changes the internal kubernetes alias for the omero-readonly servers to point to the internal IP of the proxy instead, from where the  client config file can be downloaded.