### PR TITLE
Open additional external ports for OMERO (IDR-0.4.6)

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -154,8 +154,8 @@
   version: 3.0.0
 
 - name: IDR.openstack-idr-security-groups
-  src: https://github.com/manics/ansible-role-openstack-idr-security-groups.git
-  version: omero-external-load-balance
+  src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git
+  version: 1.2.0
 
 
 ######################################################################

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -154,8 +154,8 @@
   version: 3.0.0
 
 - name: IDR.openstack-idr-security-groups
-  src: https://github.com/IDR/ansible-role-openstack-idr-security-groups.git
-  version: 1.1.0
+  src: https://github.com/manics/ansible-role-openstack-idr-security-groups.git
+  version: omero-external-load-balance
 
 
 ######################################################################


### PR DESCRIPTION
Uses dev version of openstack-idr-security-groups

- [x] --depends-on https://github.com/IDR/ansible-role-openstack-idr-security-groups/pull/3

Security groups are shared so this will open up ports for all deployments