### PR TITLE
omero-mapr version bump

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -168,7 +168,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- "git+git://github.com/sbesson/omero-mapr.git@django-redis"
+- "git+git://github.com/sbesson/omero-mapr.git@django-redis#egg=omero-mapr"
 omero_web_apps_names:
 - omero_mapr
 

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -168,7 +168,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- "git+git://github.com/sbesson/omero-mapr.git@django-redis#egg=omero-mapr"
+- "omero-mapr==0.2.1"
 omero_web_apps_names:
 - omero_mapr
 

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -168,7 +168,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- "omero-mapr==0.1.14"
+- "git+git://github.com/sbesson/omero-mapr.git@django-redis"
 omero_web_apps_names:
 - omero_mapr
 


### PR DESCRIPTION
The latest release of `django-redis 1.9.0` drops support for Django< 1.11 causing Travis and probably any new deployment of IDR due to the semantics of the requirements file in the current version of `omero-mapr`. 

This PR proposes to bump `omero-mapr` to the latest patch release fixing this issue. Travis is expected to pass with these changes.

The changes made to `omero-mapr` since `0.1.14` were mostly about documentation or testing, so this bump should have no impact on production - see the [0.2.0](https://github.com/ome/omero-mapr/milestone/16) and [0.2.1](https://github.com/ome/omero-mapr/milestone/17) milestones

--depends-on https://github.com/ome/omero-mapr/pull/33
