### PR TITLE
Bump jupyter-docker image, move docker pull task (IDR-0.4.6)

### DIFF
--- a/ansible/group_vars/dockerworker-hosts.yml
+++ b/ansible/group_vars/dockerworker-hosts.yml
@@ -5,4 +5,4 @@ kubernetes_cni_version: 0.5.1-0
 
 idr_prepull_docker_images:
 - "imagedata/jupyterhub-githubauth:0.5.0"
-- "imagedata/jupyter-docker:0.6.1"
+- "imagedata/jupyter-docker:0.7.0"

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -3,11 +3,19 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-dockermanager-hosts
     {{ idr_environment | default('idr') }}-dockerworker-hosts
+
   roles:
     - role: openmicroscopy.docker
       # Upstream requires additional kubernetes configuration
       docker_install_upstream: False
       docker_use_ipv4_nic_mtu: True
+
+  tasks:
+  - name: install docker-python
+    become: yes
+    yum:
+      name: docker-python
+      state: present
 
 
 - hosts: "{{ idr_environment | default('idr') }}-dockermanager-hosts"
@@ -29,25 +37,3 @@
       /data/mineotaur:
       - host: "*"
         options: 'rw'
-
-
-- hosts: "{{ idr_environment | default('idr') }}-dockerworker-hosts"
-
-  tasks:
-
-  - name: jupyterhub | install docker-python
-    become: yes
-    yum:
-      name: docker-python
-      state: present
-
-  - name: jupyterhub | pull docker images in advance
-    become: yes
-    docker_image:
-      name: "{{ item }}"
-      state: "present"
-      force: "{{ idr_docker_pull_latest }}"
-    with_items: "{{ idr_prepull_docker_images }}"
-
-  vars:
-  - idr_docker_pull_latest: True

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -118,6 +118,7 @@
     # Requires docker_omeroreadonly_endpoint_addresses
     - external-omero/external-service.yml
 
+
 - hosts: >
     {{ idr_environment | default('idr') }}-dockerworker-hosts
   roles:
@@ -132,6 +133,25 @@
            '-dockermanager-hosts'][0]]['ansible_' +
            (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}:6443
+
+
+- hosts: >
+    {{ idr_environment | default('idr') }}-dockermanager-hosts
+    {{ idr_environment | default('idr') }}-dockerworker-hosts
+
+  tasks:
+
+  - name: jupyterhub | pull docker images in advance
+    become: yes
+    docker_image:
+      name: "{{ item }}"
+      state: "present"
+      force: "{{ idr_docker_pull_latest }}"
+    with_items: "{{ idr_prepull_docker_images }}"
+
+  vars:
+  - idr_docker_pull_latest: True
+
 
 # Now run:
 # kubectl get nodes


### PR DESCRIPTION
- Bump docker image prepull to [`imagedata/jupyter-docker:0.7.0`](https://github.com/IDR/jupyter-docker/pull/25)
- Move the prepull task to idr-kubernetes instead of docker since it's related to the application deployment, not the underlying docker infrastructure.