### PR TITLE
Add host alias without idr-environment prefix

### DIFF
--- a/ansible/idr-bastion.yml
+++ b/ansible/idr-bastion.yml
@@ -12,3 +12,4 @@
   - role: openmicroscopy.hosts-populate
     hosts_populate_openstack_groups:
     - "{{ idr_environment | default('idr') }}-hosts"
+    hosts_populate_regex_alias: "^[^-]+-(.+)"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -27,8 +27,9 @@
 - src: openmicroscopy.haproxy
   version: 2.2.0
 
-- src: openmicroscopy.hosts-populate
-  version: 0.1.1
+- name: openmicroscopy.hosts-populate
+  src: https://github.com/manics/ansible-role-hosts-populate.git
+  version: host-alias
 
 - src: openmicroscopy.ice
   version: 2.1.1


### PR DESCRIPTION
```diff
TASK [openmicroscopy.hosts-populate : hosts | update /etc/hosts] ***************
--- before: /etc/hosts
+++ after: /var/folders/z0/tv7cs0n16m54ytpp_2tsk2c9w3bcxl/T/tmpED21bS/etc-hosts.j2
@@ -3,15 +3,15 @@
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6

 # Group test46-hosts
-192.168.29.5 test46-database
-192.168.29.10 test46-dockermanager
-192.168.29.11 test46-dockerworker-1
-192.168.29.12 test46-dockerworker-2
-192.168.29.13 test46-management
-192.168.29.14 test46-omeroreadonly-1
-192.168.29.15 test46-omeroreadonly-2
-192.168.29.16 test46-omeroreadonly-3
-192.168.29.17 test46-omeroreadonly-4
-192.168.29.6 test46-omeroreadwrite
-192.168.29.9 test46-proxy
+192.168.29.5 test46-database database
+192.168.29.10 test46-dockermanager dockermanager
+192.168.29.11 test46-dockerworker-1 dockerworker-1
+192.168.29.12 test46-dockerworker-2 dockerworker-2
+192.168.29.13 test46-management management
+192.168.29.14 test46-omeroreadonly-1 omeroreadonly-1
+192.168.29.15 test46-omeroreadonly-2 omeroreadonly-2
+192.168.29.16 test46-omeroreadonly-3 omeroreadonly-3
+192.168.29.17 test46-omeroreadonly-4 omeroreadonly-4
+192.168.29.6 test46-omeroreadwrite omeroreadwrite
+192.168.29.9 test46-proxy proxy


changed: [test46-proxy]
```