### PR TITLE
Ssl web certs new role

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -12,8 +12,8 @@ nginx_proxy_worker_processes: 4
 nginx_proxy_buffers: 32 16k
 
 nginx_proxy_ssl: True
-nginx_proxy_ssl_certificate: "{{ idr_default_nginx_proxy_ssl_certificate | default('/etc/nginx/ssl/idr-fullchain.pem') }}"
-nginx_proxy_ssl_certificate_key: "{{ idr_default_nginx_proxy_ssl_certificate_key | default('/etc/nginx/ssl/idr-privkey.pem') }}"
+nginx_proxy_ssl_certificate: /etc/ssl/localcerts/bundled.crt
+nginx_proxy_ssl_certificate_key: /etc/ssl/localcerts/server.key
 nginx_proxy_http2: True
 
 

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -86,11 +86,8 @@
     when: selinux_enabled
 
   roles:
-  # Default to a self-signed certificate, to use production certificates set:
-  # ssl_certificate_content: "{{ secret_certificate_content }}"
-  # ssl_certificate_key_content: "{{ secret_certificate_key_content }}"
-  # ssl_certificate_selfsigned_create: False
+  # Default to a self-signed certificate
+  # To use production certificates see
+  # https://github.com/openmicroscopy/ansible-role-ssl-certificate/blob/0.2.0/README.md
   - role: openmicroscopy.ssl-certificate
-    ssl_certificate_path: "{{ nginx_proxy_ssl_certificate }}"
-    ssl_certificate_key_path: "{{ nginx_proxy_ssl_certificate_key }}"
   - role: openmicroscopy.nginx-proxy

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -87,11 +87,10 @@
 
   roles:
   # Default to a self-signed certificate, to use production certificates set:
-  # idr_nginx_ssl_production: True
-  # nginx_proxy_ssl_certificate_source_path: local/path/to/certificate
-  # nginx_proxy_ssl_certificate_key_source_path: local/path/to/key
-  - role: openmicroscopy.nginx-ssl-selfsigned
-    nginx_ssl_certificate: "{{ nginx_proxy_ssl_certificate }}"
-    nginx_ssl_certificate_key: "{{ nginx_proxy_ssl_certificate_key }}"
-    when: "{{ not idr_nginx_ssl_production | default(False) | bool }}"
+  # ssl_certificate_content: "{{ secret_certificate_content }}"
+  # ssl_certificate_key_content: "{{ secret_certificate_key_content }}"
+  # ssl_certificate_selfsigned_create: False
+  - role: openmicroscopy.ssl-certificate
+    ssl_certificate_path: "{{ nginx_proxy_ssl_certificate }}"
+    ssl_certificate_key_path: "{{ nginx_proxy_ssl_certificate_key }}"
   - role: openmicroscopy.nginx-proxy

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -114,9 +114,8 @@
 - src: openmicroscopy.selinux-utils
   version: 1.0.3
 
-- name: openmicroscopy.ssl-certificate
-  src: https://github.com/manics/ansible-role-ssl-certificate.git
-  version: ssl-certificate
+- src: openmicroscopy.ssl-certificate
+  version: 0.2.0
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -115,7 +115,7 @@
   version: 1.0.3
 
 - name: openmicroscopy.ssl-certificate
-  src: https://github.com/manics/ansible-role-nginx-ssl-selfsigned.git
+  src: https://github.com/manics/ansible-role-ssl-certificate.git
   version: ssl-certificate
 
 - src: openmicroscopy.storage-volume-initialise

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -69,9 +69,6 @@
 - src: openmicroscopy.nginx-proxy
   version: 1.5.2
 
-- src: openmicroscopy.nginx-ssl-selfsigned
-  version: 1.0.0
-
 - src: openmicroscopy.omero-common
   version: 0.3.0
 
@@ -116,6 +113,10 @@
 
 - src: openmicroscopy.selinux-utils
   version: 1.0.3
+
+- name: openmicroscopy.ssl-certificate
+  src: https://github.com/manics/ansible-role-nginx-ssl-selfsigned.git
+  version: ssl-certificate
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0


### PR DESCRIPTION
Use ~~https://github.com/openmicroscopy/ansible-role-nginx-ssl-selfsigned/pull/1~~ https://github.com/openmicroscopy/ansible-role-ssl-certificate to remove the requirement for a local on-disk copy of private SSL https certs.

Closes https://github.com/IDR/deployment/issues/94