### PR TITLE
Haproxy separate TCP logs (IDR-0.4.7)

### DIFF
--- a/ansible/idr-haproxy.yml
+++ b/ansible/idr-haproxy.yml
@@ -45,7 +45,7 @@
     haproxy_cfg_template: "{{ playbook_dir }}/templates/haproxy.cfg.j2"
     # haproxy needs some special setup to log to a file
     haproxy_syslog_configure_udp: True
-    haproxy_syslog_dest: local2
+    haproxy_syslog_enable: True
 
   tasks:
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,9 +24,8 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- name: openmicroscopy.haproxy
-  src: https://github.com/manics/ansible-role-haproxy.git
-  version: restart-rsyslog
+- src: openmicroscopy.haproxy
+  version: 3.0.0
 
 - src: openmicroscopy.hosts-populate
   version: 0.1.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -24,8 +24,9 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- src: openmicroscopy.haproxy
-  version: 2.2.0
+- name: openmicroscopy.haproxy
+  src: https://github.com/manics/ansible-role-haproxy.git
+  version: restart-rsyslog
 
 - src: openmicroscopy.hosts-populate
   version: 0.1.1

--- a/ansible/templates/haproxy.cfg.j2
+++ b/ansible/templates/haproxy.cfg.j2
@@ -1,7 +1,9 @@
+# Requires "haproxy_syslog_enable: True" in the openmicroscopy.haproxy role
+
 global
   log /dev/log  local0
   log /dev/log  local1 notice
-  log 127.0.0.1 {{ haproxy_syslog_dest }}
+  log 127.0.0.1 {{ haproxy_syslog_dest }} notice
   stats socket {{ haproxy_socket }} level admin
   chroot {{ haproxy_chroot }}
   user {{ haproxy_user }}
@@ -24,6 +26,7 @@ frontend omero4064-default
     default_backend omero4064
     option tcplog
     timeout client 10m
+    log 127.0.0.1 {{ haproxy_syslog_dest_tcp }}
 
 {% for backend in omero_omeroreadonly_hosts_external %}
 frontend omero4064-{{ loop.index0 }}
@@ -32,6 +35,7 @@ frontend omero4064-{{ loop.index0 }}
     default_backend omero4064-{{ loop.index0 }}
     option tcplog
     timeout client 10m
+    log 127.0.0.1 {{ haproxy_syslog_dest_tcp }}
 {% endfor %}
 
 


### PR DESCRIPTION
This directs the incoming TCP connection logs to a separate file `/var/log/haproxy/haproxy-tcp.log`. A few non-connection logs will still creep in but these can be ignored.