### PR TITLE
Add new delete script that dynamically finds resources

### DIFF
--- a/scripts/os-idr-delete.py
+++ b/scripts/os-idr-delete.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+# Delete resources in an idr-environment
+
+import argparse
+from builtins import input
+import shade
+import sys
+
+
+def is_in_idrenv(idrenv, obj):
+    return (obj.name.startswith('%s-' % idrenv) or obj.name == idrenv)
+
+
+class DeleteServers(object):
+    def __init__(self, cloud, idrenv):
+        self.cloud = cloud
+        self.servers = [s for s in cloud.list_servers()
+                        if is_in_idrenv(idrenv, s)]
+
+        self.description = (
+            ['Deleting Servers'] +
+            ['  server {0} ({1})'.format(s.name, s.id)
+             for s in self.servers]
+        )
+
+    def __call__(self):
+        for s in self.servers:
+            self.cloud.delete_server(s.id, wait=True)
+
+    def __str__(self):
+        return '\n'.join(self.description)
+
+
+class DeleteVolumes(object):
+    def __init__(self, cloud, idrenv):
+        self.cloud = cloud
+        self.volumes = [v for v in cloud.list_volumes()
+                        if is_in_idrenv(idrenv, v)]
+        volume_ids = set(v.id for v in self.volumes)
+        self.volume_snapshots = [s for s in cloud.list_volume_snapshots()
+                                 if s.volume_id in volume_ids]
+
+        self.description = (
+            ['Deleting Volumes'] +
+            ['  volume-snapshot {0} ({1})'.format(s.name, s.id)
+             for s in self.volume_snapshots] +
+            ['  volume {0} ({1})'.format(v.name, v.id)
+             for v in self.volumes]
+        )
+
+    def __call__(self):
+        for s in self.volume_snapshots:
+            cloud.delete_volume_snapshot(s.id, wait=True)
+        for v in self.volumes:
+            self.cloud.delete_volume(v.id, wait=True)
+
+    def __str__(self):
+        return '\n'.join(self.description)
+
+
+class DeleteNetworks(object):
+    def __init__(self, cloud, idrenv):
+        self.cloud = cloud
+        self.routers = [r for r in cloud.list_routers()
+                        if is_in_idrenv(idrenv, r)]
+        self.networks = [n for n in cloud.list_networks()
+                         if is_in_idrenv(idrenv, n)]
+        self.subnet_ids = []
+        for n in self.networks:
+            self.subnet_ids.extend(n.subnets)
+
+        self.ports = {}
+        self.router_map = dict((r.id, r) for r in self.routers)
+        for n in self.networks:
+            for p in cloud.list_ports({
+                'device_owner': 'network:router_interface',
+                'network_id': n.id
+            }):
+                if p.device_id in self.router_map:
+                    try:
+                        self.ports[p.device_id].add(p.id)
+                    except KeyError:
+                        self.ports[p.device_id] = set([p.id])
+
+        # Fetch subnet metadata for display
+        subnet_dict = dict((s.id, s) for s in cloud.list_subnets())
+
+        self.description = (
+            ['Deleting Networks'] +
+            ['  ports {0}'.format(','.join(self.ports[router_id]))
+             for router_id in self.ports] +
+            ['  router {0} ({1})'.format(r.name, r.id)
+             for r in self.routers] +
+            ['  subnet {0} ({1})'.format(subnet_dict[s].name, s)
+             for s in self.subnet_ids] +
+            ['  network {0} ({1})'.format(n.name, n.id)
+             for n in self.networks]
+        )
+
+    def __call__(self):
+        for (router_id, port_ids) in self.ports.items():
+            for p in port_ids:
+                self.cloud.remove_router_interface(
+                    self.router_map[router_id], port_id=p)
+        for r in self.routers:
+            self.cloud.delete_router(r.id)
+        for s in self.subnet_ids:
+            self.cloud.delete_subnet(s)
+        for n in self.networks:
+            self.cloud.delete_network(n.id)
+
+    def __str__(self):
+        return '\n'.join(self.description)
+
+
+class DeleteSecurityGroups(object):
+    def __init__(self, cloud, idrenv):
+        self.cloud = cloud
+        self.security_groups = [g for g in cloud.list_security_groups()
+                                if is_in_idrenv(idrenv, g)]
+
+        self.description = (
+            ['Deleting Security-Groups'] +
+            ['  security-group {0} ({1})'.format(g.name, g.id)
+             for g in self.security_groups]
+        )
+
+    def __call__(self):
+        for g in self.security_groups:
+            self.cloud.delete_security_group(g.id)
+
+    def __str__(self):
+        return '\n'.join(self.description)
+
+
+def delete(cloud, idrenv, resource_types):
+    commands = []
+    delete_all = 'all' in resource_types
+
+    if delete_all or 'server' in resource_types:
+        commands.append(DeleteServers(cloud, idrenv))
+    if delete_all or 'volume' in resource_types:
+        commands.append(DeleteVolumes(cloud, idrenv))
+    if delete_all or 'network' in resource_types:
+        commands.append(DeleteNetworks(cloud, idrenv))
+    if delete_all or 'secgroup' in resource_types:
+        commands.append(DeleteSecurityGroups(cloud, idrenv))
+
+    return commands
+
+
+def parse_args(args):
+    def idrenv_validate(s):
+        if len(s) < 1:
+            raise argparse.ArgumentTypeError('Invalid idrenv')
+        return s
+
+    resource_types = (
+        'server',
+        'volume',
+        'network',
+        'secgroup',
+        'all',
+    )
+    p = argparse.ArgumentParser(description='Delete OpenStack IDR resources')
+    p.add_argument('idrenv', help='IDR Environment', type=idrenv_validate)
+    p.add_argument(
+        '--type', '-t', action='append', choices=resource_types,
+        help='OpenStack resource type(s), use "all" to delete all')
+    args = p.parse_args(args)
+    if not args.type:
+        raise argparse.ArgumentTypeError('Invalid resource type')
+    return args
+
+
+if __name__ == '__main__':
+    args = parse_args(sys.argv[1:])
+
+    if not args.idrenv.startswith('test'):
+        p = input('This is not a test environment.\n'
+                  'Enter the environment name to confirm deletion: ')
+        if p != args.idrenv:
+            print('Environment does not match, aborting')
+            sys.exit(2)
+
+    cloud = shade.openstack_cloud()
+    commands = delete(cloud, args.idrenv, args.type)
+    for c in commands:
+        print(c)
+
+    r = input('Enter "yes" to delete these resources: ')
+    if r == 'yes':
+        for c in commands:
+            print(c.description[0])
+            c()
+    else:
+        print('Aborting')
+        sys.exit(1)


### PR DESCRIPTION
With the latest changes it is impractical to hard code the list of resources that should be deleted, which is made worse by hidden dependencies (e.g. snapshots prevent volumes from being deleted).

This python script uses the `shade` module to find resources that should be deleted. A type parameter allows deletions to be restricted to `server`, `volume` (includes snapshots), `network` (includes routers and subnets), `secgroup` (Security groups and rules), or `all`. A final confirmation is required after the resources to be listed are printed out.
```
$ ./os-idr-delete.py testk8s -t all
Deleting Servers
  server testk8s-k8sproxy (6e317900-10e5-4c6a-80ed-a84391bda5ae)
  server testk8s-train-node (4c5f75a0-dbdd-4cbe-b844-cecf66bcd19d)
  server testk8s-train-master (5f0c990d-1a4d-4faf-bb7f-410d0c128854)
  server testk8s-vae-node (0f804f57-70c7-4e01-abf5-502e08a02b17)
  server testk8s-vae-master (2e0e0db6-a392-43dc-83c1-32dca40f8aa3)
Deleting Volumes
  volume-snapshot test snapshot 2 (42fcea89-55e4-4867-8a57-2e7ca4820eb0)
  volume-snapshot test snapshot (1284f314-30d4-4b80-9afa-a1babe954615)
  volume testk8s-vae-master-gluster (c70ce2cc-513a-4c4b-a4f4-1c7c684ba277)
Deleting Networks
  ports e08e437c-7459-4d18-a075-652a5c8b399d
  router testk8s-router (80852412-ab3d-429a-b624-10a0d12a9493)
  subnet testk8s-subnet (5abfe844-8ba3-40e2-bb80-b7c6fbae9920)
  network testk8s (1e1a0cc5-d76b-4d50-8696-1eb2a7444b27)
Deleting Security-Groups
  security-group testk8s-external (df97f7cb-5c7d-4adf-9289-67ee41d8b4b3)
Enter "yes" to delete these resources: yes
Deleting Servers
Deleting Volumes
Deleting Networks
Deleting Security-Groups
```
The script waits for each individual deletion to complete to avoid problems with dependent resources, so it may take a while. If you're impatient pass `--nowait` and when it fails rerun.