### PR TITLE
Bump page_limit to 500

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -161,6 +161,7 @@ omero_web_config_set:
 # https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.0-m2/components/tools/OmeroWeb/omeroweb/decorators.py#L305
   omero.web.public.cache.enabled: True
   omero.web.public.cache.timeout: 60
+  omero.web.page_size: 500
 
 
 


### PR DESCRIPTION
To workaround an off-by-one issue in a project with
200 datasets, we're temporarily upping the page size to 500.

see also: https://github.com/openmicroscopy/openmicroscopy/pull/5701