### PR TITLE
Workaround for incompatibilty between Docker 1.13.1 and Kubernetes 1.7.4

### DIFF
--- a/ansible/files/docker-1.13-kube-1.7.4-iptables.service
+++ b/ansible/files/docker-1.13-kube-1.7.4-iptables.service
@@ -1,0 +1,13 @@
+# https://github.com/kubernetes/kubernetes/issues/40182#issuecomment-276392353
+[Unit]
+Description=Override Docker 1.13.1 iptables default forward for Kubernetes 1.7.4
+After=docker.service
+#Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/iptables -P FORWARD ACCEPT
+
+[Install]
+WantedBy=multi-user.target
+

--- a/ansible/idr-kubernetes.yml
+++ b/ansible/idr-kubernetes.yml
@@ -7,6 +7,30 @@
     {{ idr_environment | default('idr') }}-proxy-hosts
 
 
+# Workaround this issue with Docker 1.13.1 and Kubernetes 1.7.4
+# https://github.com/kubernetes/kubernetes/issues/40182#issuecomment-276392353
+# We're going to drop these hosts so this is just a quick fix
+- hosts: >
+    {{ idr_environment | default('idr') }}-dockermanager-hosts
+    {{ idr_environment | default('idr') }}-dockerworker-hosts
+
+  tasks:
+
+  - name: Workaround iptables problem with Docker 1.13.1 Kubernetes 1.7.4
+    become: yes
+    copy:
+      src: files/docker-1.13-kube-1.7.4-iptables.service
+      dest: /etc/systemd/system/docker-1.13-kube-1.7.4-iptables.service
+
+  - name: Start and enable Docker Kubernetes Iptables workaround
+    become: yes
+    systemd:
+      daemon_reload: yes
+      name: docker-1.13-kube-1.7.4-iptables.service
+      enabled: yes
+      state: started
+
+
 - hosts: >
     {{ idr_environment | default('idr') }}-dockermanager-hosts
 


### PR DESCRIPTION
Since these servers will go away in the next release this is a quick fix.