### PR TITLE
Minor idempotence correction for journald dir

### DIFF
--- a/ansible/idr-centos-init.yml
+++ b/ansible/idr-centos-init.yml
@@ -10,7 +10,7 @@
       path: /var/log/journal
       owner: root
       group: systemd-journal
-      mode: "u=rwx,g=rws,o=rx"
+      mode: "u=rwx,g=rxs,o=rx"
       state: directory
     notify:
     - restart systemd-journald


### PR DESCRIPTION
When journald starts it resets the permissions on `/var/log/journal`. This PR ensures the perms set by ansible match those set by journald to avoid idempotence warnings when rerunning after journald has been restarted for other reasons.