### PR TITLE
Auto-reboot if kernel upgraded immediately after idr-00-preinstall.yml

### DIFF
--- a/ansible/idr-00-preinstall.yml
+++ b/ansible/idr-00-preinstall.yml
@@ -8,3 +8,5 @@
 - include: os-idr-volumes.yml
 - include: idr-dundee-nfs.yml
 - include: idr-ebi-nfs.yml
+
+- include: idr-reboot-if-kernel.yml


### PR DESCRIPTION
This reduces but does not eliminate some long standing issues with race conditions during reboots. The original aim of this repository was to support a full deployment run-through from scratch, with reboots postponed to the very end. In practice this causes problems when installed services are unnecessarily interrupted, or when a service is installed against an old running kernel which changes after the reboot. Instead this PRs executes the reboot at the end of the pre-install stage, after system packages have been upgraded but before any applications are installed.

This will lead to the first full run-through failing after the preinstall stage since the combination of multiple VM reboots via a proxy and rebooting the proxy makes it too complicated to auto-detect when all VMs have resumed, however this is preferable to other problems caused later.