### PR TITLE
Bump to OMERO 0.4.7

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.4.6"
+idr_omero_release: "0.4.7"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -169,7 +169,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- "omero-mapr==0.2.1"
+- "omero-mapr==0.2.2"
 omero_web_apps_names:
 - omero_mapr
 


### PR DESCRIPTION
This is an emergency release of OMERO to fix
failing pip installations of omero-marshal.

see: https://github.com/openmicroscopy/omero-marshal/pull/50