### PR TITLE
Block proxy /webclient/login

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -224,6 +224,9 @@ nginx_proxy_direct_locations:
   redirect302: /webclient/?experimenter=-1
 - location: "= /"
   redirect302: /about
+  # Block webclient login
+- location: "^~ /webclient/login"
+  redirect302: /webclient/?experimenter=-1
 - location: "^~ /about"
   alias: /srv/www/html
 - location: "^~ /connection"


### PR DESCRIPTION
This blocks the OMERO.web login page on the front-end proxy to prevent private state from being cached. See https://github.com/IDR/deployment/pull/110#discussion_r183026496