### PR TITLE
WIP: Test omeroreadonly in molecule

### DIFF
--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -9,9 +9,6 @@
 - include: idr-omero-web.yml
 
 - include: idr-omero-readonly.yml
-  tags:
-  # Requires NFS shares which can't be configured in Docker
-  - skip_if_molecule_docker
 
 - include: idr-docker.yml
 

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -188,5 +188,7 @@
 
   roles:
   - role: openmicroscopy.omero-server
+    when: not (TRAVIS | default(False))
+
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -18,6 +18,10 @@
 
   - role: openmicroscopy.nfs-share
     nfs_shares:
+      # WARNING: This makes /data the root for all exports from this server
+      /data:
+      - host: "*"
+        options: 'ro,fsid=0'
       /data/OMERO:
       - host: "*"
         options: 'ro'
@@ -58,13 +62,13 @@
   - role: openmicroscopy.nfs-mount
     nfs_share_mounts:
     - path: /data/OMERO-readonly
-      location: "{{ omero_fileserver_host_ansible }}:/data/OMERO"
+      location: "{{ omero_fileserver_host_ansible }}:/OMERO"
       opts: ro,soft
     - path: /data/BioFormatsCache
-      location: "{{ omero_fileserver_host_ansible }}:/data/BioFormatsCache"
+      location: "{{ omero_fileserver_host_ansible }}:/BioFormatsCache"
       opts: rw,,soft,sync
     - path: /data/idr-metadata
-      location: "{{ omero_fileserver_host_ansible }}:/data/idr-metadata"
+      location: "{{ omero_fileserver_host_ansible }}:/idr-metadata"
       opts: ro,soft
 
   # Include restart handlers

--- a/ansible/molecule-playbook.yml
+++ b/ansible/molecule-playbook.yml
@@ -13,6 +13,14 @@
   - debug:
       msg: "{{ hostvars[groups[idr_environment | default('idr') + '-proxy-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
 
+  - name: Set variable if in travis so we can disable some tasks
+    set_fact:
+      TRAVIS: "{{ lookup('env', 'TRAVIS') == 'true' }}"
+
+  - debug:
+      msg: "Running in travis, disabling some tasks to reduce resource usage"
+    when: TRAVIS
+
 
 # This shouldn't be necessary, but there is a bug in some CentOS 7 cloud
 # releases (2017-01-19)

--- a/ansible/molecule.yml
+++ b/ansible/molecule.yml
@@ -24,6 +24,9 @@ docker:
     image: manics/centos-systemd-ip-docker
     image_version: latest
     privileged: True
+    volume_mounts:
+      # This allows NFS exports to work on Docker
+      idr-omeroreadwrite-docker-data: /data
     ansible_groups:
     - idr-omero-hosts
     - omero-hosts
@@ -163,8 +166,6 @@ openstack:
 
 ansible:
   playbook: molecule-playbook.yml
-  # TODO: Only skip when driver==docker
-  skip_tags: skip_if_molecule_docker
 
   group_vars:
 

--- a/ansible/tests/test_omeroreadonly.py
+++ b/ansible/tests/test_omeroreadonly.py
@@ -1,10 +1,13 @@
 import testinfra.utils.ansible_runner
 import pytest
+import os
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('omeroreadonly-hosts')
 
 
+@pytest.mark.skipif(os.getenv('TRAVIS') == 'true',
+                    reason="Disabled on travis: insufficient resources")
 @pytest.mark.parametrize("name", ["omero-server", "omero-web", "nginx"])
 def test_services_running_and_enabled(Service, name):
     service = Service(name)
@@ -12,10 +15,14 @@ def test_services_running_and_enabled(Service, name):
     assert service.is_enabled
 
 
+@pytest.mark.skipif(os.getenv('TRAVIS') == 'true',
+                    reason="Disabled on travis: insufficient resources")
 def test_nginx_port_listening(Socket):
     assert Socket("tcp://0.0.0.0:80").is_listening
 
 
+@pytest.mark.skipif(os.getenv('TRAVIS') == 'true',
+                    reason="Disabled on travis: insufficient resources")
 @pytest.mark.parametrize("port", [4063, 4064])
 def test_omero_port_listening(Socket, port):
     # For some reason OMERO may listen on ipv6 instead of ipv4
@@ -23,5 +30,7 @@ def test_omero_port_listening(Socket, port):
             Socket("tcp://:::%d" % port).is_listening)
 
 
+@pytest.mark.skipif(os.getenv('TRAVIS') == 'true',
+                    reason="Disabled on travis: insufficient resources")
 def test_registry_port_listening(Socket):
     assert Socket("tcp://127.0.0.1:4061").is_listening

--- a/ansible/tests/test_omeroreadonly.py
+++ b/ansible/tests/test_omeroreadonly.py
@@ -1,0 +1,27 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('omeroreadonly-hosts')
+
+
+@pytest.mark.parametrize("name", ["omero-server", "omero-web", "nginx"])
+def test_services_running_and_enabled(Service, name):
+    service = Service(name)
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_nginx_port_listening(Socket):
+    assert Socket("tcp://0.0.0.0:80").is_listening
+
+
+@pytest.mark.parametrize("port", [4063, 4064])
+def test_omero_port_listening(Socket, port):
+    # For some reason OMERO may listen on ipv6 instead of ipv4
+    assert (Socket("tcp://0.0.0.0:%d" % port).is_listening or
+            Socket("tcp://:::%d" % port).is_listening)
+
+
+def test_registry_port_listening(Socket):
+    assert Socket("tcp://127.0.0.1:4061").is_listening

--- a/ansible/tests/test_omeroreadwrite.py
+++ b/ansible/tests/test_omeroreadwrite.py
@@ -1,7 +1,6 @@
 import testinfra.utils.ansible_runner
 import pytest
 
-# TODO: This should be 'omero-hosts' if we get it deployed in docker
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('omeroreadwrite-hosts')
 
@@ -20,8 +19,8 @@ def test_nginx_port_listening(Socket):
 @pytest.mark.parametrize("port", [4063, 4064])
 def test_omero_port_listening(Socket, port):
     # For some reason OMERO may listen on ipv6 instead of ipv4
-    assert (Socket("tcp://0.0.0.0:%d" % port).is_listening or
-            Socket("tcp://:::%d" % port).is_listening)
+    assert (Socket("tcp://127.0.0.1:%d" % port).is_listening or
+            Socket("tcp://::1%d" % port).is_listening)
 
 
 def test_registry_port_listening(Socket):


### PR DESCRIPTION
This changes the NFS exports on omeroreadwrite to be relative to `/data` instead of `/` by setting `fsid=0`. The primary benefit of this is it means omero readonly should be testable with molecule docker. Previously it was disabled as the OMERO data dir couldn't be mounted on the read-only servers in docker due to the docker filesystem type. Making `omeroreadwrite:/data` an external docker volume in molecule gets around this problem.

The server side data volumes are unchanged, this only affects the client-side mounts on the read-only servers. Since prod50 is already deployed we should save this for test51/prod51. However, it should be possible to test this locally alongside https://github.com/IDR/deployment/pull/103