### PR TITLE
Update default FTP size and allow it to be configurable

### DIFF
--- a/ansible/openstack-create-ftp.yml
+++ b/ansible/openstack-create-ftp.yml
@@ -76,7 +76,7 @@
   # Volumes
 
   - role: openmicroscopy.openstack-volume-storage
-    openstack_volume_size: 5000
+    openstack_volume_size: "{{ idr_environment_ftp_size | default(15000) }}"
     openstack_volume_vmname: "{{ idr_environment_idr }}-ftp"
     openstack_volume_name: ftpdata
     openstack_volume_device: /dev/vdb


### PR DESCRIPTION
Follow-up of #117, this addition was used when recreating the IDR FTP service to match the recent extension of the volume.

The default is bumped to 15TB and a new `idr_environment_ftp_size` variable is added to override it via Ansible variables. Alternatively, we could set a much smaller default in the public playbook e.g. 100GB and move the production idr-ftp value to the host variable.