### PR TITLE
Make idr-management:/data into a volume (IDR-0.5.1)

### DIFF
--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -132,3 +132,14 @@
       idr_vm_management: True
       idr_vm_networks:
       - net-name: "{{ idr_environment_idr }}"
+
+
+    ############################################################
+    # Management Volume (do not copy when upgrading)
+
+    - role: openmicroscopy.openstack-volume-storage
+      openstack_volume_size: 100
+      openstack_volume_vmname: "{{ idr_environment_idr }}-management"
+      openstack_volume_name: data
+      openstack_volume_device: /dev/vdb
+      openstack_volume_source: "{{ idr_volume_proxy_nginxcache_src }}"

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -130,6 +130,8 @@
       idr_vm_image: "{{ vm_image }}"
       idr_vm_flavour: "{{ vm_flavour_medium }}"
       idr_vm_management: True
+      idr_vm_extra_groups:
+      - "{{ idr_environment_idr }}-data-hosts"
       idr_vm_networks:
       - net-name: "{{ idr_environment_idr }}"
 
@@ -142,4 +144,3 @@
       openstack_volume_vmname: "{{ idr_environment_idr }}-management"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdb
-      openstack_volume_source: "{{ idr_volume_proxy_nginxcache_src }}"


### PR DESCRIPTION
We're generating a lot of logs and metrics (or there's a misconfiguration which means the  elasticsearch logs aren't being deleted after 14 days). This should ensure they're stored on a 100GB volume instead of in the root partition.

https://trello.com/c/PmYJjRO1/45-make-idr-management-data-into-a-volume

Untested.