### PR TITLE
Update requirements.yml to consume haproxy 3.1.0

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -28,8 +28,8 @@
   version: 1.0.0
 
 - name: openmicroscopy.haproxy
-  src: https://github.com/ajardan/ansible-role-haproxy.git
-  version: master
+  src: https://github.com/openmicroscopy/ansible-role-haproxy/archive/74c7a08d72faec1f95f70eb6ace33ac7502fc397.tar.gz
+  version: 74c7a08d72faec1f95f70eb6ace33ac7502fc397
 
 - src: openmicroscopy.hosts-populate
   version: 0.2.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -27,8 +27,9 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- src: openmicroscopy.haproxy
-  version: 3.0.0
+- name: openmicroscopy.haproxy
+  src: https://github.com/ajardan/ansible-role-haproxy.git
+  version: master
 
 - src: openmicroscopy.hosts-populate
   version: 0.2.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -28,7 +28,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.haproxy
-  version: 3.1.0
+  version: 3.2.0
 
 - src: openmicroscopy.hosts-populate
   version: 0.2.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -27,9 +27,8 @@
 - src: openmicroscopy.docker-tools
   version: 1.0.0
 
-- name: openmicroscopy.haproxy
-  src: https://github.com/openmicroscopy/ansible-role-haproxy/archive/74c7a08d72faec1f95f70eb6ace33ac7502fc397.tar.gz
-  version: 74c7a08d72faec1f95f70eb6ace33ac7502fc397
+- src: openmicroscopy.haproxy
+  version: 3.1.0
 
 - src: openmicroscopy.hosts-populate
   version: 0.2.0


### PR DESCRIPTION
As discussed earlier, the goal is to test the external changes proposed in https://github.com/openmicroscopy/ansible-role-haproxy/pull/12 against a complete deployment (`test51`)