### PR TITLE
rsync download is on omeroreadwrite host

### DIFF
--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -44,7 +44,7 @@
       omero_downloads_host_ansible: >-
         {{
           hostvars[groups[
-            idr_environment | default('idr') + '-omero-hosts'][0]]
+            idr_environment | default('idr') + '-omeroreadwrite-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
     when: "{{ groups[idr_environment | default('idr') + '-omero-hosts'] is defined }}"


### PR DESCRIPTION
The rsync data source is only on the read-write omero server.