### PR TITLE
Bump maximum plane dimensions above which pyramids are calculated

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -57,6 +57,8 @@ omero_server_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"
+  omero.pixeldata.max_plane_width: 5100
+  omero.pixeldata.max_plane_height: 5100
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -59,7 +59,7 @@ omero_server_config_set:
   omero.jvmcfg.heap_size.blitz: "24G"
   omero.pixeldata.max_plane_width: 5300
   omero.pixeldata.max_plane_height: 5300
-  omero.fs.repo.path: "%user%_%userId%//%year%-%month%/%day%/%time%-%hash%"
+  omero.fs.repo.path: "%user%_%userId%//%year%-%month%/%day%/%time%/%hash%"
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -57,8 +57,8 @@ omero_server_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"
-  omero.pixeldata.max_plane_width: 5100
-  omero.pixeldata.max_plane_height: 5100
+  omero.pixeldata.max_plane_width: 5300
+  omero.pixeldata.max_plane_height: 5300
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -59,6 +59,7 @@ omero_server_config_set:
   omero.jvmcfg.heap_size.blitz: "24G"
   omero.pixeldata.max_plane_width: 5300
   omero.pixeldata.max_plane_height: 5300
+  omero.fs.repo.path: "%user%_%userId%//%year%-%month%/%day%/%time%-%hash%"
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"


### PR DESCRIPTION
See https://trello.com/c/gBAAQTIY/47-hpa-run-1-idr0043

Some of the TIFF are larger than the current 3192x3192 limit causing pyramids to be generated. This change increases the threshold to 5100x5100 to test the import of the first set of antibodies.