### PR TITLE
Improve idr-proxy web test

### DIFF
--- a/ansible/tests/test_proxy.py
+++ b/ansible/tests/test_proxy.py
@@ -2,7 +2,7 @@ import testinfra.utils.ansible_runner
 import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    '.molecule/ansible_inventory').get_hosts('omero-hosts')
+    '.molecule/ansible_inventory').get_hosts('proxy-hosts')
 
 
 def test_services_running_and_enabled(Service):
@@ -11,7 +11,6 @@ def test_services_running_and_enabled(Service):
     assert service.is_enabled
 
 
-# @pytest.mark.parametrize("port", [80, 443, 9000])
-@pytest.mark.parametrize("port", [80])
+@pytest.mark.parametrize("port", [80, 443, 9000])
 def test_omero_port_listening(Socket, port):
     assert Socket("tcp://0.0.0.0:%d" % port).is_listening

--- a/ansible/tests/test_proxy.py
+++ b/ansible/tests/test_proxy.py
@@ -14,3 +14,12 @@ def test_services_running_and_enabled(Service):
 @pytest.mark.parametrize("port", [80, 443, 9000])
 def test_omero_port_listening(Socket, port):
     assert Socket("tcp://0.0.0.0:%d" % port).is_listening
+
+
+@pytest.mark.parametrize("address", [
+    "http://localhost/",
+    "https://localhost/",
+])
+def test_html_index(Command, address):
+    out = Command.check_output('curl -kL %s' % address)
+    assert '<title>IDR: Image Data Resource</title>' in out


### PR DESCRIPTION
Fixes a long standing error (testing the wrong server).

Also adds a basic test to ensure the web page is correct.

@sbesson It'd be worth getting this in before the new idr website deployment change.