### PR TITLE
Use new deploy_archive role for deploying idr website

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -319,15 +319,13 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-#idr_openmicroscopy_org_version: "2018.08.01"
-idr_openmicroscopy_org_version: idr-www-test
+idr_openmicroscopy_org_version: 2018.08.09
 deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
-#deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_website_version }}/idr.openmicroscopy.org.tar.gz
-deploy_archive_src_url: http://users.openmicroscopy.org.uk/~spli/idr/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
+deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: 01301f2cf4e5be55aa53976b35b989b96f4547c3a12746f781be4d45f11331fe
+deploy_archive_sha256: 94390e762fc28047c80218dd9812391cab77dcf04cee3f65e0e95fda51e81c89
 deploy_archive_symlink: /srv/www/html
 idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
 idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -319,13 +319,17 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-jekyll_build_sourcedir: /srv/www/src/about
-jekyll_build_root: /srv/www/html
-jekyll_build_git_repo: https://github.com/IDR/idr.openmicroscopy.org.git
-jekyll_build_force_git: True
-jekyll_build_baseurl: /about
-jekyll_build_config:
-- /srv/www/src/about-config.yml
+#idr_website_version: "2018.08.01"
+idr_website_version: idr-www-test
+deploy_archive_dest_dir: /srv/www/{{ idr_website_version }}
+#deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_website_version }}/idr.openmicroscopy.org.tar.gz
+deploy_archive_src_url: http://users.openmicroscopy.org.uk/~spli/idr/{{ idr_website_version }}/idr.openmicroscopy.org.tar.gz
+# Optional checksum. It should be safe to omit as long as you never
+# overwrite an existing archive. This should not be a problem when using
+# versioned directories.
+deploy_archive_sha256: 32ddcd688381c9af66f1ff2f8d3534f21066d249bbb46c16cb4db50d2e963843
+deploy_archive_symlink: /srv/www/html
+idr_website_version_file: /srv/www/{{ idr_website_version }}/VERSION
 
 idr_openmicroscopy_org_config:
   idr_deployment_version: "{{ idr_environment | default('idr') }}"

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -319,22 +319,18 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-#idr_website_version: "2018.08.01"
-idr_website_version: idr-www-test
-deploy_archive_dest_dir: /srv/www/{{ idr_website_version }}
+#idr_openmicroscopy_org_version: "2018.08.01"
+idr_openmicroscopy_org_version: idr-www-test
+deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
 #deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_website_version }}/idr.openmicroscopy.org.tar.gz
-deploy_archive_src_url: http://users.openmicroscopy.org.uk/~spli/idr/{{ idr_website_version }}/idr.openmicroscopy.org.tar.gz
+deploy_archive_src_url: http://users.openmicroscopy.org.uk/~spli/idr/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
 deploy_archive_sha256: 32ddcd688381c9af66f1ff2f8d3534f21066d249bbb46c16cb4db50d2e963843
 deploy_archive_symlink: /srv/www/html
-idr_website_version_file: /srv/www/{{ idr_website_version }}/VERSION
-
-idr_openmicroscopy_org_config:
-  idr_deployment_version: "{{ idr_environment | default('idr') }}"
-#  idr_deployment_date: "DD MMM YYYY"
-#  idr_deployment_notes: "https://example.org/release-notes"
+idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
+idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"
 
 
 ######################################################################

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -327,7 +327,7 @@ deploy_archive_src_url: http://users.openmicroscopy.org.uk/~spli/idr/{{ idr_open
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: 32ddcd688381c9af66f1ff2f8d3534f21066d249bbb46c16cb4db50d2e963843
+deploy_archive_sha256: 01301f2cf4e5be55aa53976b35b989b96f4547c3a12746f781be4d45f11331fe
 deploy_archive_symlink: /srv/www/html
 idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
 idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -2,36 +2,14 @@
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
 
-  pre_tasks:
-
-  # This seems complicated because the config file needs to exist before
-  # jekyll-build, but we also want to notify jekyll-build of changes which
-  # can't be done until after the jekyll-build role
-
-  - name: create jekyll config directory
-    become: yes
-    file:
-      path: "{{ jekyll_build_config.0 | dirname }}"
-      recurse: yes
-      state: directory
-
-  - name: create dummy jekyll config
-    become: yes
-    copy:
-      content: ''
-      dest: "{{ jekyll_build_config.0 }}"
-      # Only create if it doesn't exist
-      force: no
-
   roles:
-  - role: openmicroscopy.jekyll-build
+  - role: openmicroscopy.deploy_archive
+    become: yes
 
   tasks:
-  - name: create jekyll config
+  - name: Set website displayed version
     become: yes
     copy:
-      content: "{{ idr_openmicroscopy_org_config | to_nice_yaml }}"
-      dest: "{{ jekyll_build_config.0 }}"
+      content: "{{ idr_openmicroscopy_org_config.idr_deployment_version }}"
+      dest: "{{ idr_website_version_file }}"
       force: yes
-    notify:
-    - jekyll build

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -10,6 +10,6 @@
   - name: Set website displayed version
     become: yes
     copy:
-      content: "{{ idr_openmicroscopy_org_config.idr_deployment_version }}"
-      dest: "{{ idr_website_version_file }}"
+      content: "{{ idr_deployment_web_version_value }}"
+      dest: "{{ idr_deployment_web_version_file }}"
       force: yes

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -21,6 +21,9 @@
 - src: openmicroscopy.cli-utils
   version: 1.0.0
 
+- src: openmicroscopy.deploy_archive
+  version: 0.1.1
+
 - src: openmicroscopy.docker
   version: 2.2.0
 
@@ -38,9 +41,6 @@
 
 - src: openmicroscopy.java
   version: 2.0.1
-
-- src: openmicroscopy.jekyll-build
-  version: 1.2.1
 
 - src: openmicroscopy.local-accounts
   version: 1.0.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -22,7 +22,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.deploy_archive
-  version: 0.1.1
+  version: 0.1.2
 
 - src: openmicroscopy.docker
   version: 2.2.0


### PR DESCRIPTION
Replace jekyll build with a pre-built artefact containing the IDR `/about` pages.

Due to the changes required in https://github.com/IDR/idr.openmicroscopy.org this is currently using a temporary build http://users.openmicroscopy.org.uk/~spli/idr/idr-www-test/idr.openmicroscopy.org.tar.gz

Before deploying this manually run `cd /srv/www; sudo mv html html.old && sudo ln -s html.old html`

- [x] --depends-on https://github.com/openmicroscopy/ansible-role-deploy-archive/pull/2 for a selinux fix (I haven't bumped requirements yet because this doesn't affect travis/docker tests).