### PR TITLE
Shared buffers bump

### DIFF
--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -36,15 +36,5 @@ idr_omero_readonly_database:
 
 postgresql_install_extensions: True
 
-# TODO: add a variable to easily enable/disable
-# TESTING ONLY!
-#postgresql_server_conf:
-#pg_stat_staments?
-#  shared_preload_libraries: "'pg_stat_statements'"
-#  pg_stat_statements.max: 20000
-#Database tuning?
-#  default_statistics_target = 1000
-#  maintenance_work_mem = 256MB
-#  checkpoint_completion_target = 0.9
-#  effective_cache_size = "{{ (ansible_memtotal_mb / 2) | int }}MB"
-#  work_mem = 64MB
+postgresql_server_conf:
+  shared_buffers: 1GB

--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -37,4 +37,4 @@ idr_omero_readonly_database:
 postgresql_install_extensions: True
 
 postgresql_server_conf:
-  shared_buffers: 1GB
+  shared_buffers: "{{ (ansible_memtotal_mb / 4) | int }}MB"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -100,7 +100,7 @@
   version: 1.1.0
 
 - src: openmicroscopy.postgresql
-  version: 3.0.0-m2
+  version: 3.0.1
 
 - src: openmicroscopy.python-pydata
   version: 1.0.0


### PR DESCRIPTION
See https://trello.com/b/AM7jhXRQ/idr-051

As tested during the IDR 0.5.0 by @mtbc, this PR bumps the value of `shared_buffers` to 1GB using the `postgresql_server_conf` dictionary. Additionally it bumps `openmicroscopy.postgresql` to the latest version of the role. This should be harmless as there has been no change in the logic in the role, only documentation - see https://github.com/openmicroscopy/ansible-role-postgresql/compare/3.0.0-m2...3.0.1.