### PR TITLE
Bump all Ansible roles to latest release

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -10,13 +10,13 @@
   version: 1.0.0
 
 - src: openmicroscopy.anonymous-ftp
-  version: 0.1.0
+  version: 0.1.1
 
 - src: openmicroscopy.basedeps
   version: 1.0.0
 
 - src: openmicroscopy.cadvisor
-  version: 0.1.1
+  version: 0.2.0
 
 - src: openmicroscopy.cli-utils
   version: 1.0.0
@@ -25,7 +25,7 @@
   version: 0.1.2
 
 - src: openmicroscopy.docker
-  version: 2.2.0
+  version: 2.3.0
 
 - src: openmicroscopy.docker-tools
   version: 1.0.0
@@ -49,7 +49,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.lvm-partition
-  version: 1.0.0
+  version: 1.1.0
 
 - src: openmicroscopy.munin
   version: 1.1.3-openmicroscopy1
@@ -61,16 +61,16 @@
   version: 1.2.1
 
 - src: openmicroscopy.nfs-mount
-  version: 1.0.0
+  version: 1.1.0
 
 - src: openmicroscopy.nfs-share
-  version: 1.0.1
+  version: 1.0.2
 
 - src: openmicroscopy.nginx
   version: 1.0.0
 
 - src: openmicroscopy.nginx-proxy
-  version: 1.5.2
+  version: 1.8.0
 
 - src: openmicroscopy.omero-common
   version: 0.3.0
@@ -85,13 +85,13 @@
   version: 1.1.0
 
 - src: openmicroscopy.omero-server
-  version: 2.0.0-m4
+  version: 2.0.5
 
 - src: openmicroscopy.omero-user
   version: 0.1.1
 
 - src: openmicroscopy.omero-web
-  version: 1.0.0-m3
+  version: 2.0.0
 
 - src: openmicroscopy.omero-web-apps
   version: 0.1.0
@@ -118,7 +118,7 @@
   version: 1.0.3
 
 - src: openmicroscopy.ssl-certificate
-  version: 0.2.0
+  version: 0.2.1
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0
@@ -177,8 +177,8 @@
   version: 0.1.0
 
 - name: openmicroscopy.omero-web-django-prometheus
-  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.1.0.tar.gz
-  version: 0.1.0
+  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
+  version: 0.2.0
 
 - name: openmicroscopy.prometheus
   src: openmicroscopy.ansible-role-prometheus


### PR DESCRIPTION
We seem to be lagging behind a bit.

Working on the assumption that we're correctly using semver only the following need to be reviewed:
- [ ] openmicroscopy.cadvisor 0.1.1 → 0.2.0
- [ ] openmicroscopy.omero-web 1.0.0-m3 → 2.0.0
- [ ] openmicroscopy.omero-web-django-prometheus 0.1.0 → 0.2.0