### PR TITLE
Install and config for django-cors-headers

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -163,9 +163,6 @@ omero_web_config_set:
   omero.web.public.cache.timeout: 60
   omero.web.page_size: 500
 
-  # NB: See additional CORS config below
-  omero.web.cors_origin_allow_all: True
-
 ######################################################################
 # Plugins and additional web configuration
 
@@ -264,6 +261,7 @@ omero_web_apps_config_append:
     class: "corsheaders.middleware.CorsPostCsrfMiddleware"
 # set...
 omero_web_apps_config_set:
+  omero.web.cors_origin_allow_all: True
   omero.web.mapr.config:
   - menu: "gene"
     config:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -170,8 +170,10 @@ omero_web_config_set:
 
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
+- "django-cors-headers"
 omero_web_apps_names:
 - omero_mapr
+- corsheaders
 
 omero_web_apps_top_links:
 - label: Studies
@@ -251,8 +253,15 @@ omero_web_apps_ui_metadata_panes:
   label: "Others"
   index: 6
 
-# Additional plugin config (append)
-#omero_web_apps_config_append:
+# Additional plugin config
+# append...
+omero_web_apps_config_append:
+  omero.web.middleware:
+  - index: 0.5
+    class": "corsheaders.middleware.CorsMiddleware"
+  - index: 10
+    class": "corsheaders.middleware.CorsPostCsrfMiddleware"
+# set...
 omero_web_apps_config_set:
   omero.web.mapr.config:
   - menu: "gene"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -258,9 +258,9 @@ omero_web_apps_ui_metadata_panes:
 omero_web_apps_config_append:
   omero.web.middleware:
   - index: 0.5
-    class": "corsheaders.middleware.CorsMiddleware"
+    class: "corsheaders.middleware.CorsMiddleware"
   - index: 10
-    class": "corsheaders.middleware.CorsPostCsrfMiddleware"
+    class: "corsheaders.middleware.CorsPostCsrfMiddleware"
 # set...
 omero_web_apps_config_set:
   omero.web.mapr.config:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -163,7 +163,8 @@ omero_web_config_set:
   omero.web.public.cache.timeout: 60
   omero.web.page_size: 500
 
-
+  # NB: See additional CORS config below
+  omero.web.cors_origin_allow_all: True
 
 ######################################################################
 # Plugins and additional web configuration

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -94,7 +94,7 @@
   version: 1.0.0-m3
 
 - src: openmicroscopy.omero-web-apps
-  version: 0.1.0
+  version: 0.1.1
 
 - src: openmicroscopy.openstack-volume-storage
   version: 1.1.0


### PR DESCRIPTION
See https://trello.com/c/EpmQzvoy/2-json-api-publicly-accessible-with-cors

Trying to add CORS support as described at https://docs.openmicroscopy.org/omero/5.4.7/sysadmins/unix/install-web.html#setting-up-cors

Not sure I quite understand how to perform these append steps:
```
$ bin/omero config append omero.web.middleware '{"index": 0.5, "class": "corsheaders.middleware.CorsMiddleware"}'
$ bin/omero config append omero.web.middleware '{"index": 10, "class": "corsheaders.middleware.CorsPostCsrfMiddleware"}'
```
since all the other configs seem to be "set" but I uncommented out the ```omero_web_apps_config_append``` and added yml there which I hope will be appended as JSON, but I don't really know if/how this works or how to test it.

cc @manics @sbesson 