### PR TITLE
test52: OMERO.server changes

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -57,7 +57,7 @@ omero_server_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"
-  omero.fs.repo.path: "%user%_%userId%_%thread%//%year%-%month%/%day%/%time%"
+  omero.fs.repo.path: "%user%_%userId%/%thread%//%year%-%month%/%day%/%time%"
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -57,7 +57,7 @@ omero_server_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"
-  omero.fs.repo.path: "%user%_%userId%//%year%-%month%/%day%/%time%-%hash%"
+  omero.fs.repo.path: "%user%_%userId%_%thread%//%year%-%month%/%day%/%time%"
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.5.0"
+idr_omero_release: "0.5.1-rc1"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -57,6 +57,7 @@ omero_server_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"
+  omero.fs.repo.path: "%user%_%userId%//%year%-%month%/%day%/%time%-%hash%"
   # public user doesn;t share omero session between visitors
   #omero.sessions.timeout: 3600000
   omero.policy.binary_access: "+read,+write,-image,-plate"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.5.1-rc1"
+idr_omero_release: "0.5.1"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False


### PR DESCRIPTION
This PR contains OMERO.server changes for `test52`:

- 8895f22 bumps the version of OMERO to use `0.5.1-rc1` which includes  the 5.4.8-rc1 tag of OMERO with all the parallel import features  - see https://trello.com/c/i0JAPzgB/13-omero-548-rc1
-  1452eed and 164c846 increase the height and the width of the maximum plane size to import the first run of HPA data - see https://trello.com/c/gBAAQTIY/47-hpa-run-1-idr0043
- 4c4c25b updates `omero.fs.repo.path` to contend with parallel imports using the `-%hash` suffix
