### PR TITLE
Adjust maximum plane height and width

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -69,6 +69,9 @@ omero_server_config_set:
   # Tree display
   omero.client.ui.tree.type_order: False
   omero.client.ui.tree.orphans.enabled: False
+  # Maximum plane size
+  omero.pixeldata.max_plane_width: 5300
+  omero.pixeldata.max_plane_height: 5300
 
 
 ######################################################################


### PR DESCRIPTION
This change is required to import the first run of Human Protein Atlas data without generating TBs of OMERO pyramids.