### PR TITLE
Bump to IDR OMERO 0.5.2

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.5.1"
+idr_omero_release: "0.5.2"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False


### PR DESCRIPTION
The only difference with b8e4b155ad4fcca0027fd1ce6a4bb9faa50c189f are the last set of PRs included in the public release of OMERO 5.4.8 (see https://github.com/openmicroscopy/openmicroscopy/pull/5872). This should not have any impact in the case of IDR but reduces the delta between the IDR version of OMERO and mainline OMERO to its current minimum.