### PR TITLE
Auto-restart after SSL update, revert to previous Nginx logging format

### DIFF
--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -74,3 +74,11 @@
   # https://github.com/openmicroscopy/ansible-role-ssl-certificate/blob/0.2.0/README.md
   - role: openmicroscopy.ssl-certificate
   - role: openmicroscopy.nginx-proxy
+
+  handlers:
+  - name: restart nginx when certificates changed
+    listen: ssl certificate changed
+    become: yes
+    service:
+      name: nginx
+      state: restarted

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -70,7 +70,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.nginx-proxy
-  version: 1.8.0
+  version: 1.7.0
 
 - src: openmicroscopy.omero-common
   version: 0.3.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -117,8 +117,9 @@
 - src: openmicroscopy.selinux-utils
   version: 1.0.3
 
-- src: openmicroscopy.ssl-certificate
-  version: 0.2.1
+- name: openmicroscopy.ssl-certificate
+  src: https://github.com/openmicroscopy/ansible-role-ssl-certificate/archive/f36523ddc9eb8f71d32a4fa3f1438be609ce9c77.tar.gz
+  version: f36523ddc9eb8f71d32a4fa3f1438be609ce9c77
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -117,9 +117,8 @@
 - src: openmicroscopy.selinux-utils
   version: 1.0.3
 
-- name: openmicroscopy.ssl-certificate
-  src: https://github.com/openmicroscopy/ansible-role-ssl-certificate/archive/f36523ddc9eb8f71d32a4fa3f1438be609ce9c77.tar.gz
-  version: f36523ddc9eb8f71d32a4fa3f1438be609ce9c77
+- src: openmicroscopy.ssl-certificate
+  version: 0.3.0
 
 - src: openmicroscopy.storage-volume-initialise
   version: 1.0.0


### PR DESCRIPTION
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-ssl-certificate/pull/11

This also reverts `openmicroscopy.nginx-proxy` role to `1.7.0` to ensure the Nginx log format is identical to the existing production (prod51) format. Longer term we either need to modify the role to a support the IDR's log format, or update all our log analytics tools to accept both formats.