### PR TITLE
Install iviewer 0.6.0 as a secondary image viewer

### DIFF
--- a/ansible/experimental-omero-web-addons.yml
+++ b/ansible/experimental-omero-web-addons.yml
@@ -28,24 +28,3 @@
       dest: "{{ omero_common_basedir }}/web/config/fpbioimage.omero"
     notify:
     - restart omero-web
-
-  - name: omero-web iviewer install
-    become: yes
-    pip:
-      name: omero-iviewer
-      state: present
-      version: 0.2.0
-      virtualenv: "{{ omero_common_basedir }}/web/venv"
-      virtualenv_site_packages: yes
-    notify:
-    - restart omero-web
-
-  - name: omero-web iviewer configure
-    become: yes
-    copy:
-      content: |
-        config append -- omero.web.apps '"omero_iviewer"'
-        config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"script_url": "omero_iviewer/openwith.js", "supported_objects":["image"], "label": "OMERO.iviewer"}]'
-      dest: "{{ omero_common_basedir }}/web/config/iviewer.omero"
-    notify:
-    - restart omero-web

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -171,9 +171,11 @@ omero_web_config_set:
 
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
+- "omero-iviewer==0.6.0"
 - "django-cors-headers"
 omero_web_apps_names:
 - omero_mapr
+- omero_iviewer
 - corsheaders
 
 omero_web_apps_top_links:
@@ -262,6 +264,14 @@ omero_web_apps_config_append:
     class: "corsheaders.middleware.CorsMiddleware"
   - index: 10
     class: "corsheaders.middleware.CorsPostCsrfMiddleware"
+  omero.web.open_with:
+  - - omero_iviewer
+    - omero_iviewer_index
+    - script_url: omero_iviewer/openwith.js
+      supported_objects:
+      - image
+      label: OMERO.iviewer
+
 # set...
 omero_web_apps_config_set:
   omero.web.cors_origin_allow_all: True

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -103,6 +103,7 @@ idr_omero_web_public_url_filters:
 - api/
 - webadmin/myphoto/
 - mapr/
+- iviewer/
 - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
 - webgateway/(?!(archived_files|download_as))
 

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -42,6 +42,8 @@ _nginx_proxy_omero_locations:
 - /webclient/api/*
 - /webclient/search/*
 - /mapr/*
+# TODO: Does iviewer need to be cached?
+#- /iviewer/*
 
 _nginx_proxy_backends_omero:
 - name: omerocached


### PR DESCRIPTION
Install latest iviewer on test60 so we can assess how far we are from making it the default IDR viewer. See:
- https://trello.com/c/LdGRTtZI/7-omeroiviewer-potential-blockers

Nginx caching is ***not*** activated at the moment.