### PR TITLE
0.6.0 rc3

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -159,12 +159,12 @@ omero_web_config_set:
   omero.web.ui.top_links: []
   omero.web.ui.metadata_panes: []
   omero.web.wsgi_timeout: "{{ idr_omero_web_timeout | default(60) }}"
-
 # TODO: This needs careful review of the code
 # https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.0-m2/components/tools/OmeroWeb/omeroweb/decorators.py#L305
   omero.web.public.cache.enabled: True
   omero.web.public.cache.timeout: 60
   omero.web.page_size: 500
+  omero.web.user_dropdown: "{{ idr_omero_web_user_dropdown | default(true) }}"
 
 ######################################################################
 # Plugins and additional web configuration

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.6.0-rc2"
+idr_omero_release: "0.6.0-rc3"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/group_vars/omeroreadonly-hosts.yml
+++ b/ansible/group_vars/omeroreadonly-hosts.yml
@@ -7,3 +7,4 @@ omero_server_dbuser: omeroreadonly
 omero_server_dbpassword: "{{ idr_secret_postgresql_password_ro | default('omero') }}"
 
 omero_server_datadir_manage: False
+idr_omero_web_user_dropdown: false


### PR DESCRIPTION
Includes the changes merged in https://github.com/openmicroscopy/openmicroscopy/pull/5909 and to be released as OMERO 5.4.10 /cc @jburel 

The  `omero.web.user_dropdown` option should remove the login dropdown from the read-only deployments (proxied by the `idr-proxy`) but maintain an Login option on the read-write deployment for edition of the top-level containers.

Since `test60` is currently used for testing the Bio-Formats cache regeneration, proposing to deploy this on `prod60`