### PR TITLE
prod60: final deployment tweaks

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_release: "0.6.0-rc3"
+idr_omero_release: "0.6.0"
 idr_omero_ice_version: "3.6"
 # Upgrades are normally disabled, set to True upgrade OMERO:
 idr_omero_upgrade: False

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -321,16 +321,14 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-idr_openmicroscopy_org_version: 2018.08.09
+idr_openmicroscopy_org_version: 2018.11.29
 deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
 deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: 94390e762fc28047c80218dd9812391cab77dcf04cee3f65e0e95fda51e81c89
+deploy_archive_sha256: 3357a1bd5d59df69b630bacc37f4a35afbfd22f50442d34bfd6c65ba29c367e2
 deploy_archive_symlink: /srv/www/html
-idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
-idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"
 
 
 ######################################################################

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -6,10 +6,3 @@
   - role: openmicroscopy.deploy_archive
     become: yes
 
-  tasks:
-  - name: Set website displayed version
-    become: yes
-    copy:
-      content: "{{ idr_deployment_web_version_value }}"
-      dest: "{{ idr_deployment_web_version_file }}"
-      force: yes

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -5,4 +5,3 @@
   roles:
   - role: openmicroscopy.deploy_archive
     become: yes
-


### PR DESCRIPTION
- use final `0.6.0` version of IDR-OMERO (including https://github.com/IDR/bioformats/pull/10)
- update `/about` pages to use the latest website including studies/releases stats and about page updates