### PR TITLE
Add overarching decommissioning playbook

### DIFF
--- a/ansible/decommission/playbook.yml
+++ b/ansible/decommission/playbook.yml
@@ -1,0 +1,4 @@
+---
+- include: archive-db.yml
+- include: archive-instance-services.yml
+- include: archive-logs.yml


### PR DESCRIPTION
See https://github.com/IDR/deployment/pull/144#pullrequestreview-173398053

While decommissioning `prod52`, I realized that the steps had to be run in a specific order. This playbook captures this order to simplify.

Note the steps aggregating/copying the various dumps/archives to `/uod/idr/versions` is not implemented but could probably be conceived as a folllow-up playbook.