### PR TITLE
Set omero.web.api.max_limit 1000

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -116,6 +116,7 @@ omero_web_omego_additional_args: "{{ idr_omero_omego_additional_args }}"
 
 omero_web_config_set:
   # web
+  omero.web.api.max_limit: 1000
   omero.web.application_server: wsgi-tcp
   omero.web.application_server.max_requests: 30000
   omero.web.wsgi_workers: 25


### PR DESCRIPTION
This should allow up to 1000 ROIs to be shown in iviewer, but will also allow larger API queries. Needs testing.

See https://trello.com/c/LdGRTtZI/1-omeroiviewer-as-the-default-viewer#comment-5bf52300aafbb91554148bfe