### PR TITLE
idrftp alternate user account

### DIFF
--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -24,7 +24,7 @@
     become: yes
     group:
       gid: "{{ idrftp_alternate_user_id | default(omit) }}"
-      name: "{{ idrftp_alternate_user_name | default('test') }}"
+      name: "{{ idrftp_alternate_user_name | default('ftp-upload') }}"
       state: present
       system: no
 
@@ -33,10 +33,10 @@
     user:
       append: no
       createhome: yes
-      group: "{{ idrftp_alternate_user_name | default('test') }}"
+      group: "{{ idrftp_alternate_user_name | default('ftp-upload') }}"
       groups: ""
-      home: /data/"{{ idrftp_alternate_user_name | default('test') }}"
-      name: "{{ idrftp_alternate_user_name | default('test') }}"
+      home: /data/"{{ idrftp_alternate_user_name | default('ftp-upload') }}"
+      name: "{{ idrftp_alternate_user_name | default('ftp-upload') }}"
       # Lock account, it will be manually enabled when needed
       password: "!"
       state: present

--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -17,3 +17,29 @@
     #anonymous_ftp_incoming_group:
     #anonymous_ftp_emails:
     #anonymous_ftp_public_address:
+
+  tasks:
+
+  - name: ftp | create alternate upload group
+    become: yes
+    group:
+      gid: "{{ idrftp_alternate_user_id | default(omit) }}"
+      name: "{{ idrftp_alternate_user_name | default('test') }}"
+      state: present
+      system: no
+
+  - name: ftp | create alternate upload user
+    become: yes
+    user:
+      append: no
+      createhome: yes
+      group: "{{ idrftp_alternate_user_name | default('test') }}"
+      groups: ""
+      home: /data/"{{ idrftp_alternate_user_name | default('test') }}"
+      name: "{{ idrftp_alternate_user_name | default('test') }}"
+      # Lock account, it will be manually enabled when needed
+      password: "!"
+      state: present
+      uid: "{{ idrftp_alternate_user_id | default(omit) }}"
+      # Change to always to always lock the account when this playbook is run
+      update_password: on_create


### PR DESCRIPTION
Creates a locked local account on the IDR FTP server.
This account can be manually unlocked and a password set when required.