### PR TITLE
Bump DB volume size to 300

### DIFF
--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -101,7 +101,7 @@
     # IDR Volumes
 
     - role: openmicroscopy.openstack-volume-storage
-      openstack_volume_size: 250
+      openstack_volume_size: 300
       openstack_volume_vmname: "{{ idr_environment_idr }}-database"
       openstack_volume_name: db
       openstack_volume_device: /dev/vdb

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -101,7 +101,7 @@
     # IDR Volumes
 
     - role: openmicroscopy.openstack-volume-storage
-      openstack_volume_size: 300
+      openstack_volume_size: 500
       openstack_volume_vmname: "{{ idr_environment_idr }}-database"
       openstack_volume_name: db
       openstack_volume_device: /dev/vdb


### PR DESCRIPTION
Candidate for `prod62`. As demonstrated by https://github.com/IDR/idr.openmicroscopy.org/pull/40, we are getting closer to the volume limit on the production IDR database instance. This raises the size to 300GB instead.