### PR TITLE
k8s API access must be tunnelled via k8sproxy

### DIFF
--- a/ansible/templates/k8sproxy-haproxy.cfg.j2
+++ b/ansible/templates/k8sproxy-haproxy.cfg.j2
@@ -78,7 +78,7 @@ backend web-train-http
 # certificates
 
 frontend kubernetes-api-vae
-    bind *:6450
+    bind localhost:6450
     mode tcp
     default_backend kubernetes-api-vae
     option tcplog
@@ -86,7 +86,7 @@ frontend kubernetes-api-vae
     log 127.0.0.1 {{ haproxy_syslog_dest_tcp }}
 
 frontend kubernetes-api-train
-    bind *:6451
+    bind localhost:6451
     mode tcp
     default_backend kubernetes-api-train
     option tcplog


### PR DESCRIPTION
Prevent external K8s API access.

This increases security by requiring K8s API access to be either tunnelled via the proxy (ssh proxy, connect to localhost), or from within the cluster (the GitLab runner is hosted inside the cluster and therefore has internal API access).

Relevant playbook: `ansible/k8s-k8sproxy.yml`