### PR TITLE
Restore idr deployment version

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -329,6 +329,8 @@ deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/d
 # versioned directories.
 deploy_archive_sha256: e10529bdbf81a5aba02375ee19e82ce382192a004b3bbae90cb136b14d452122
 deploy_archive_symlink: /srv/www/html
+idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
+idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"
 
 
 ######################################################################

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -5,3 +5,11 @@
   roles:
   - role: openmicroscopy.deploy_archive
     become: yes
+
+  tasks:
+  - name: Set website displayed version
+    become: yes
+    copy:
+      content: "{{ idr_deployment_web_version_value }}"
+      dest: "{{ idr_deployment_web_version_file }}"
+      force: yes


### PR DESCRIPTION
The version: field in the footer is intended to show the deployment (prodXX, testXX, etc).

This partially reverts #148 which made it static

See
- https://github.com/IDR/idr.openmicroscopy.org/pull/33
- https://github.com/IDR/idr.openmicroscopy.org/pull/42