### PR TITLE
Increase omeroreadwrite vol to 1000 GB

### DIFF
--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -108,7 +108,7 @@
       openstack_volume_source: "{{ idr_volume_database_db_src }}"
 
     - role: openmicroscopy.openstack-volume-storage
-      openstack_volume_size: 500
+      openstack_volume_size: 1000
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdb


### PR DESCRIPTION
`prod63-omeroreadwrite` was manually resized: https://trello.com/c/sAMTUk7D/3-resize-omeroreadwrite-volume