### PR TITLE
Change cache_validity to 1d, background update, update nginx-proxy

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -20,7 +20,12 @@ nginx_proxy_http2: True
 ######################################################################
 # OMERO.web proxy
 
-nginx_proxy_log_format: main_timed_cache_upstream
+nginx_proxy_log_format_custom: >
+  '$remote_addr - $remote_user [$time_local] "$request"
+  $status $body_bytes_sent "$http_referer"
+  "$http_user_agent" "$http_x_forwarded_for"
+  $request_time $upstream_cache_status $upstream_addr'
+nginx_proxy_log_format: custom
 
 nginx_proxy_websockets_enable: True
 

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -100,7 +100,6 @@ nginx_proxy_cache_key_map:
 nginx_proxy_cache_ignore_headers: '"Set-Cookie" "Vary" "Expires"'
 nginx_proxy_cache_hide_headers:
 - Set-Cookie
-nginx_proxy_debug_cache_headers: True
 
 nginx_proxy_cache_match_uri:
 #- '"~webclient/api/paths_to_object*"'

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -49,11 +49,11 @@ _nginx_proxy_backends_omero:
 - name: omerocached
   location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
   server: http://omeroreadonly
-  cache_validity: 1d
+  cache_validity: 15m
 - name: omerostatic
   location: ~ /static/*
   server: http://omeroreadonly
-  cache_validity: 1d
+  cache_validity: 15m
 - name: omero
   location: /
   server: http://omeroreadonly

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -49,11 +49,11 @@ _nginx_proxy_backends_omero:
 - name: omerocached
   location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
   server: http://omeroreadonly
-  cache_validity: 180d
+  cache_validity: 1d
 - name: omerostatic
   location: ~ /static/*
   server: http://omeroreadonly
-  cache_validity: 30d
+  cache_validity: 1d
 - name: omero
   location: /
   server: http://omeroreadonly
@@ -242,13 +242,13 @@ _nginx_proxy_sites:
     - name: omerocached
       location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
       server: http://omeroreadwrite
-      cache_validity: 180d
+      cache_validity: 1d
       # For populating the cache we need to increase the default timeout
       read_timeout: 600
     - name: omerostatic
       location: ~ /static/*
       server: http://omeroreadwrite
-      cache_validity: 30d
+      cache_validity: 1d
     - name: omero
       location: /
       server: http://omeroreadwrite
@@ -262,13 +262,13 @@ _nginx_proxy_sites:
     - name: omerocached
       location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
       server: http://omeroreadwrite
-      cache_validity: 180d
+      cache_validity: 1d
       # For populating the cache we need to increase the default timeout
       read_timeout: 600
     - name: omerostatic
       location: ~ /static/*
       server: http://omeroreadwrite
-      cache_validity: 30d
+      cache_validity: 1d
     - name: omero
       location: /
       server: http://omeroreadwrite

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -49,11 +49,11 @@ _nginx_proxy_backends_omero:
 - name: omerocached
   location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
   server: http://omeroreadonly
-  cache_validity: 15m
+  cache_validity: 1d
 - name: omerostatic
   location: ~ /static/*
   server: http://omeroreadonly
-  cache_validity: 15m
+  cache_validity: 1d
 - name: omero
   location: /
   server: http://omeroreadonly

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -20,12 +20,7 @@ nginx_proxy_http2: True
 ######################################################################
 # OMERO.web proxy
 
-nginx_proxy_log_format_custom: >
-  '$remote_addr - $remote_user [$time_local] "$request"
-  $status $body_bytes_sent "$http_referer"
-  "$http_user_agent" "$http_x_forwarded_for"
-  $request_time $upstream_cache_status $upstream_addr'
-nginx_proxy_log_format: custom
+nginx_proxy_log_format: main_timed_cache_upstream
 
 nginx_proxy_websockets_enable: True
 

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -41,7 +41,7 @@ _nginx_proxy_omero_locations:
 - /webgateway/get_thumbnail*
 - /webclient/api/*
 - /webclient/search/*
-- /mapr/*
+# /mapr/* is handled separately due to timeouts
 # TODO: Does iviewer need to be cached?
 #- /iviewer/*
 
@@ -50,6 +50,10 @@ _nginx_proxy_backends_omero:
   location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
   server: http://omeroreadonly
   cache_validity: 1d
+- name: omeromapr
+  location: ~ /mapr/*
+  server: http://omeroreadonly
+  cache_validity: 180d
 - name: omerostatic
   location: ~ /static/*
   server: http://omeroreadonly
@@ -240,7 +244,7 @@ _nginx_proxy_sites:
     nginx_proxy_cachebuster_enabled: True
     nginx_proxy_backends:
     - name: omerocached
-      location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
+      location: ~ {{ _nginx_proxy_omero_locations | join('|') }}|/mapr/*
       server: http://omeroreadwrite
       cache_validity: 1d
       # For populating the cache we need to increase the default timeout
@@ -260,7 +264,7 @@ _nginx_proxy_sites:
     nginx_proxy_ssl: False
     nginx_proxy_backends:
     - name: omerocached
-      location: ~ {{ _nginx_proxy_omero_locations | join('|') }}
+      location: ~ {{ _nginx_proxy_omero_locations | join('|') }}|/mapr/*
       server: http://omeroreadwrite
       cache_validity: 1d
       # For populating the cache we need to increase the default timeout

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -100,6 +100,7 @@ nginx_proxy_cache_key_map:
 nginx_proxy_cache_ignore_headers: '"Set-Cookie" "Vary" "Expires"'
 nginx_proxy_cache_hide_headers:
 - Set-Cookie
+nginx_proxy_debug_cache_headers: True
 
 nginx_proxy_cache_match_uri:
 #- '"~webclient/api/paths_to_object*"'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -69,8 +69,10 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-- src: openmicroscopy.nginx-proxy
-  version: 1.7.0
+# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21/commits/e7c410179e47b73f430fa24dcd8bf874c6fcdf96
+- name: openmicroscopy.nginx-proxy
+  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/e7c410179e47b73f430fa24dcd8bf874c6fcdf96.tar.gz
+  version: e7c410179e47b73f430fa24dcd8bf874c6fcdf96
 
 - src: openmicroscopy.omero-common
   version: 0.3.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -71,8 +71,8 @@
 
 # https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21/commits/e7c410179e47b73f430fa24dcd8bf874c6fcdf96
 - name: openmicroscopy.nginx-proxy
-  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/e7c410179e47b73f430fa24dcd8bf874c6fcdf96.tar.gz
-  version: e7c410179e47b73f430fa24dcd8bf874c6fcdf96
+  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/1cf2ef1e7c6005a9466743eb654bd6fbd8c433dd.tar.gz
+  version: 1cf2ef1e7c6005a9466743eb654bd6fbd8c433dd
 
 - src: openmicroscopy.omero-common
   version: 0.3.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -69,10 +69,8 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21
-- name: openmicroscopy.nginx-proxy
-  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/c40457e10201df03d5f3ecf81670e09e06cf9f8c.tar.gz
-  version: c40457e10201df03d5f3ecf81670e09e06cf9f8c
+- src: openmicroscopy.nginx-proxy
+  version: 1.9.0
 
 - src: openmicroscopy.omero-common
   version: 0.3.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -69,10 +69,10 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21/commits/e7c410179e47b73f430fa24dcd8bf874c6fcdf96
+# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21
 - name: openmicroscopy.nginx-proxy
-  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/1cf2ef1e7c6005a9466743eb654bd6fbd8c433dd.tar.gz
-  version: 1cf2ef1e7c6005a9466743eb654bd6fbd8c433dd
+  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/c40457e10201df03d5f3ecf81670e09e06cf9f8c.tar.gz
+  version: c40457e10201df03d5f3ecf81670e09e06cf9f8c
 
 - src: openmicroscopy.omero-common
   version: 0.3.0


### PR DESCRIPTION
This only decreases the Nginx expiry cache time, the inactive time is unchanged. This means if a cache update fails Nginx should return the stale version instead of failing (and should continue to refresh in the background)

Requires:
- [x] https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21

Closes https://github.com/IDR/deployment/issues/141