### PR TITLE
Testing: redirect /studies/idrNNNN to project/screen

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -177,7 +177,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
 - "omero-iviewer==0.6.0"
-- https://gitlab.com/openmicroscopy/incubator/omero-idirector/-/archive/master/omero-idirector-master.tar.gz
+- https://gitlab.com/openmicroscopy/incubator/omero-idirector/-/archive/v0.2.0/omero-idirector-v0.2.0.tar.gz
 - "django-cors-headers==2.4.1"
 omero_web_apps_names:
 - omero_mapr

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -103,6 +103,7 @@ idr_omero_web_public_url_filters:
 - api/
 - webadmin/myphoto/
 - mapr/
+- studies/
 - iviewer/
 - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
 - webgateway/(?!(archived_files|download_as))
@@ -176,10 +177,12 @@ omero_web_config_set:
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
 - "omero-iviewer==0.6.0"
+- https://gitlab.com/openmicroscopy/incubator/omero-idirector/-/archive/master/omero-idirector-master.tar.gz
 - "django-cors-headers==2.4.1"
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer
+- omero_idirector
 - corsheaders
 
 omero_web_apps_top_links:
@@ -419,3 +422,9 @@ omero_web_apps_config_set:
         - "openmicroscopy.org/omero/bulk_annotations"
       label: "Others"
   omero.web.viewer.view: omero_iviewer.views.index
+  omero.web.idirector.prefix: studies
+  omero.web.idirector.types:
+    - Project
+    - Screen
+  omero.web.idirector.validre: 'idr\d{4}$'
+  omero.web.idirector.match: '{u}-%'

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -42,6 +42,7 @@ _nginx_proxy_omero_locations:
 - /webclient/api/*
 - /webclient/search/*
 - /mapr/*
+- /studies/*
 # TODO: Does iviewer need to be cached?
 #- /iviewer/*
 
@@ -108,6 +109,7 @@ nginx_proxy_cache_match_uri:
 - '"~webclient/api/*"'
 - '"~static/*"'
 - '"~mapr/*"'
+- '"~studies/*"'
 - '"~grafana/*"'
 
 #nginx_proxy_cache_match_arg:
@@ -157,6 +159,12 @@ nginx_proxy_caches:
   inactive: 180d
   match:
   - '"~mapr/*"'
+- name: omerostudies
+  maxsize: 200m
+  keysize: 1m
+  inactive: 180d
+  match:
+  - '"~studies/*"'
 - name: grafana
   maxsize: 100m
   keysize: 1m


### PR DESCRIPTION
Installs and configures https://gitlab.com/openmicroscopy/incubator/omero-idirector. this will redirect
`https://idr-proxy/studies/idrNNNN` to a Project or Screen with name matching `idrNNNN-*` (if there are multiple matches this will currently [go to the lowest ID](https://gitlab.com/openmicroscopy/incubator/omero-idirector/blob/v0.1.0/omero_idirector/views.py#L43)).