### PR TITLE
Cap version of django-cors-header deployed in IDR

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -174,7 +174,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
 - "omero-iviewer==0.6.0"
-- "django-cors-headers"
+- "django-cors-headers==2.4.1"
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer


### PR DESCRIPTION
The [version 2.5.0](https://pypi.org/project/django-cors-headers/2.5.0/) of django-cors-headers released 7 days ago drops support for Django 1.10 and earlier which breaks the current Web stack.

Noticed while deploying `prod65`. This [Travis build](https://travis-ci.org/sbesson/deployment/jobs/499443321) should illustrate the problem with the stack trace while deploying IDR.

Travis green should confirm this works with the current version of Django asked by OMERO.web.