### PR TITLE
Bump static website version to 2019.03.29

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -321,13 +321,13 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-idr_openmicroscopy_org_version: 2019.02.26
+idr_openmicroscopy_org_version: 2019.03.19
 deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
 deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: f9a51480e0d4bbda6088448f5da9e51ea87fffcd31ef0ba5944c3fb700c8c6f0
+deploy_archive_sha256: 5bee5913d60f1e79cf2283ad52f9aaca3c1b2c98b5b8b6f506ae2c37a70c01d0
 deploy_archive_symlink: /srv/www/html
 idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
 idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"


### PR DESCRIPTION
- new studies statistics including prod65 publications
- first version. of Aspera download page