### PR TITLE
Cap molecule to <2.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 install:
-  - pip install "ome-ansible-molecule<0.5"
+  - pip install "ome-ansible-molecule<0.5" "molecule<2.20"
 
 script:
   # TODO: molecule will only run ansible-lint on the target playbook,


### PR DESCRIPTION
A recent update to molecule has led to failures in this repo (might just be linting/formatting). Since other roles such as https://travis-ci.org/openmicroscopy/ansible-role-python-pydata seem fine this caps molecule for this repo only until we have time to investigate and update.