### PR TITLE
os-idr-snapshot.sh volumes only

### DIFF
--- a/scripts/os-idr-snapshot.sh
+++ b/scripts/os-idr-snapshot.sh
@@ -47,4 +47,10 @@ fi
 if [ $vol_errors -ne 0 ]; then
     echo "ERROR: $vol_errors volume snapshots failed"
 fi
-exit $errors
+if [ $errors -ne 0 ]; then
+    exit $errors
+fi
+
+while openstack image list --private -f json | jq ".[] | select((.Name|test(\"${vm_prefix}-\")) and (.Status != \"active\"))"; do
+    sleep 30
+done

--- a/scripts/os-idr-snapshot.sh
+++ b/scripts/os-idr-snapshot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Snapshot IDR OpenStack volumes and instances
+# Snapshot IDR OpenStack volumes
 
 # Attempt to continue on error
 #set -e
@@ -12,21 +12,7 @@ fi
 
 vm_prefix="$1"
 today=$(date +%Y%m%d)
-vm_errors=0
 vol_errors=0
-
-for vm in \
-        database \
-        omeroreadwrite \
-        proxy \
-        management \
-        ; do
-    server="$vm_prefix-$vm"
-    echo "Snapshotting server $server"
-    openstack server image create --name "$server-$today" "$server" -f yaml
-    [ $? -eq 0 ] || let vm_errors++
-    echo
-done
 
 for vol in \
         database-db \
@@ -40,17 +26,7 @@ for vol in \
     echo
 done
 
-let errors=($vm_errors + $vol_errors)
-if [ $vm_errors -ne 0 ]; then
-    echo "ERROR: $vm_errors server snapshots failed"
-fi
 if [ $vol_errors -ne 0 ]; then
     echo "ERROR: $vol_errors volume snapshots failed"
+    exit $vol_errors
 fi
-if [ $errors -ne 0 ]; then
-    exit $errors
-fi
-
-while openstack image list --private -f json | jq ".[] | select((.Name|test(\"${vm_prefix}-\")) and (.Status != \"active\"))"; do
-    sleep 30
-done


### PR DESCRIPTION
As discussed in slack this removes the instance snapshots, only volumes are snapshot.

To be tested on the next release