### PR TITLE
Move CORS header to Nginx, cache /api

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -176,11 +176,9 @@ omero_web_config_set:
 omero_web_apps_packages:
 - "omero-mapr==0.2.3"
 - "omero-iviewer==0.6.0"
-- "django-cors-headers==2.4.1"
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer
-- corsheaders
 
 omero_web_apps_top_links:
 - label: Studies
@@ -263,11 +261,6 @@ omero_web_apps_ui_metadata_panes:
 # Additional plugin config
 # append...
 omero_web_apps_config_append:
-  omero.web.middleware:
-  - index: 0.5
-    class: "corsheaders.middleware.CorsMiddleware"
-  - index: 10
-    class: "corsheaders.middleware.CorsPostCsrfMiddleware"
   omero.web.open_with:
   - - omero_iviewer
     - omero_iviewer_index
@@ -280,7 +273,6 @@ omero_web_apps_config_append:
 
 # set...
 omero_web_apps_config_set:
-  omero.web.cors_origin_allow_all: True
   omero.web.mapr.config:
   - menu: "gene"
     config:

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -41,6 +41,7 @@ _nginx_proxy_omero_locations:
 - /webgateway/get_thumbnail*
 - /webclient/api/*
 - /webclient/search/*
+- /api/*
 # /mapr/* is handled separately due to timeouts
 # TODO: Does iviewer need to be cached?
 #- /iviewer/*
@@ -154,7 +155,7 @@ nginx_proxy_caches:
   keysize: 320m
   inactive: 180d
   match:
-  - '"~webclient/api/*"'
+  - '"~(webclient/)?api/*"'
 - name: omeromapr
   maxsize: 5g
   keysize: 100m

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -110,7 +110,7 @@ nginx_proxy_cache_match_uri:
 #- '"~webclient/api/paths_to_object*"'
 - '"~web(client|gateway)/(metadata|render)_*"'
 - '"~web(client|gateway)/get_thumbnail*"'
-- '"~webclient/api/*"'
+- '"~(webclient/)?api/*"'
 - '"~static/*"'
 - '"~mapr/*"'
 - '"~grafana/*"'

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -238,7 +238,11 @@ nginx_proxy_additional_maps:
   to: $allow_origin
   mapvalues:
   - "default *"
-  - "~. $http_origin"
+# For now unconditionally return "*" in the Origin header
+# Replace with this line to return the provided header (but be aware it may be
+# necessary to return addiitonal headers)
+#  - "~. $http_origin"
+  - "~. *"
 
 
 ######################################################################

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -229,6 +229,18 @@ nginx_proxy_direct_locations:
   alias: /srv/www/letsencrypt/challenge
 
 
+# CORS: basically allow any cross-site since this is public read-only
+# Always set a header:
+# - Return the client's header (should be the requesting domain) if one given
+# - "*" otherwise
+nginx_proxy_additional_maps:
+- from: $http_origin
+  to: $allow_origin
+  mapvalues:
+  - "default *"
+  - "~. $http_origin"
+
+
 ######################################################################
 # Additional sites/virtualhosts
 _nginx_proxy_sites:
@@ -236,6 +248,9 @@ _nginx_proxy_sites:
   # This enables the default site (configured using the global
   # nginx_proxy_* variables):
   - nginx_proxy_is_default: True
+    # Only add this CORS header to the default public site
+    nginx_proxy_additional_directives:
+    - "add_header Access-Control-Allow-Origin $allow_origin"
 
   # This is a duplicate of the main OMERO.web proxy configuration, but with
   # cache-busting:

--- a/ansible/molecule/publicidr/tests/test_proxy.py
+++ b/ansible/molecule/publicidr/tests/test_proxy.py
@@ -1,4 +1,5 @@
 import os
+import re
 import testinfra.utils.ansible_runner
 import pytest
 
@@ -24,3 +25,28 @@ def test_omero_port_listening(host, port):
 def test_html_index(host, address):
     out = host.check_output('curl -kL %s' % address)
     assert '<title>IDR: Image Data Resource</title>' in out
+
+
+@pytest.mark.parametrize("curl_args,expected_header", [
+    ("http://localhost/api/v0/",
+     "Access-Control-Allow-Origin: *"),
+    ("-H 'Origin: http://example.org' http://localhost/api/v0/",
+     "Access-Control-Allow-Origin: http://example.org"),
+    ("-H 'Origin: http://example.com' http://localhost/api/v0/",
+     "Access-Control-Allow-Origin: http://example.com"),
+])
+def test_curl_headers(host, curl_args, expected_header):
+    out = host.check_output('curl -I %s' % curl_args)
+    assert expected_header in out.splitlines()
+
+
+@pytest.mark.parametrize("path", [
+    "/api/v0/",
+    "/static/webgateway/img/ome.ico",
+])
+def test_is_cached(host, path):
+    # Request twice to ensure it's cached
+    host.check_output('curl http://localhost%s' % path)
+    host.check_output('curl http://localhost%s' % path)
+    log = host.file("/var/log/nginx/access.log").content
+    assert re.search('"GET %s HTTP/1.1" 200 .+ HIT -' % path, log)

--- a/ansible/molecule/publicidr/tests/test_proxy.py
+++ b/ansible/molecule/publicidr/tests/test_proxy.py
@@ -31,9 +31,9 @@ def test_html_index(host, address):
     ("http://localhost/api/v0/",
      "Access-Control-Allow-Origin: *"),
     ("-H 'Origin: http://example.org' http://localhost/api/v0/",
-     "Access-Control-Allow-Origin: http://example.org"),
+     "Access-Control-Allow-Origin: *"),
     ("-H 'Origin: http://example.com' http://localhost/api/v0/",
-     "Access-Control-Allow-Origin: http://example.com"),
+     "Access-Control-Allow-Origin: *"),
 ])
 def test_curl_headers(host, curl_args, expected_header):
     out = host.check_output('curl -I %s' % curl_args)

--- a/ansible/molecule/publicidr/tests/test_proxy.py
+++ b/ansible/molecule/publicidr/tests/test_proxy.py
@@ -48,5 +48,5 @@ def test_is_cached(host, path):
     # Request twice to ensure it's cached
     host.check_output('curl http://localhost%s' % path)
     host.check_output('curl http://localhost%s' % path)
-    log = host.file("/var/log/nginx/access.log").content
+    log = host.file("/var/log/nginx/access.log").content.decode()
     assert re.search('"GET %s HTTP/1.1" 200 .+ HIT -' % path, log)

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -70,7 +70,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.nginx-proxy
-  version: 1.9.0
+  version: 1.10.0
 
 - src: openmicroscopy.omero-common
   version: 0.3.0


### PR DESCRIPTION
https://trello.com/c/GpXEHzjV/519-cors-access-control-allow-origin-cached

https://github.com/IDR/deployment/pull/133/ added the CORS plugin to OMERO.web.
This doesn't work as expected because the idr-proxy Nginx caches the `Origin` header, which may contain the domain of the requesting client. This means it won't work for anyone visiting another domain from the cache version.

Instead this reverts the PR and unconditionally sets the CORS `Origin` header in the Nginx proxy config. This should be OK because idr.openmicroscopy.org is strictly a read-only public site, modifications are done by tunnelling and passing the proxy. If this changes in future this must be reviewed (though in that case the whole caching setup will need review which is an even bigger issue).

This also adds `/api` to the list of cached URLs (expiry 24h, matching all other cached URLs apart from mapr) since it looks like it'll be seeing heavy use from client UI applications.

Not yet deployed

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Directives