### PR TITLE
OMERO.web public: change `/gallery` to `/gallery-api`

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -104,7 +104,7 @@ idr_omero_web_public_url_filters:
 - webadmin/myphoto/
 - mapr/
 - iviewer/
-- gallery/
+- gallery-api/
 - webclient/(?!({{ idr_omero_web_public_url_filters_webclient_exclude | join('|') }}))
 - webgateway/(?!(archived_files|download_as))
 


### PR DESCRIPTION
I have no idea why this is needed. `/cell` and `/tissue` worked whereas `/gallery-api` didn't. I have no idea why `/gallery` does not seem to be required.