### PR TITLE
Use final version of apps and website for IDR 0.6.7 release

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -175,9 +175,9 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- "omero-mapr==0.3.0a3"
-- "omero-iviewer==0.7.1"
-- omero-gallery==3.2.0a6
+- omero-mapr==0.3.0
+- omero-iviewer==0.7.1
+- omero-gallery==3.2.0a7
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -346,13 +346,13 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-idr_openmicroscopy_org_version: 2019.06.11
+idr_openmicroscopy_org_version: 2019.06.17
 deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
 deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: 20dbacf880505b196005878efc1fb372b1b119504b1a96b1bd62afbe5b8b2814
+deploy_archive_sha256: 21b9c71915a7bbf059b1aba2e3536799003c1fe999fe9f876826af9b46c0a8d4
 deploy_archive_symlink: /srv/www/html
 idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
 idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"


### PR DESCRIPTION
- `omero-mapr 0.3.0` has been released without change since the last pre-release
- `omero-gallery 2.3.0a7` includes https://github.com/ome/omero-gallery/pull/41
- `idr.openmicroscopy.org` includes the new studies published in `prod67`