### PR TITLE
Add config for Gallery study_short_name.

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -506,5 +506,5 @@ omero_web_apps_config_set:
   omero.web.gallery.title: "Welcome to IDR"
   omero.web.gallery.study_short_name:
   - key: "Name"
-  - regex: "^(.*?)-.*?(.)$"
-  - template: "{{1}}{{2}}"
+    regex: "^(.*?)-.*?(.)$"
+    template: "\{\{1}}\{\{2}}"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -503,7 +503,8 @@ omero_web_apps_config_set:
       title: "Welcome to Tissue-IDR"
       query: "Sample Type:tissue"
       image: "https://idr.openmicroscopy.org/webgateway/render_image_region/5470164/0/0/?region=1024,1024,696,520"
-  omero.web.gallery.title: "Welcome to IDR"
+  omero.web.gallery.title: "IDR: Image Data Resource"
+  omero.web.gallery.heading: "Welcome to IDR"
   omero.web.gallery.study_short_name:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -507,4 +507,4 @@ omero_web_apps_config_set:
   omero.web.gallery.study_short_name:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"
-    template: "\{\{1}}\{\{2}}"
+    template: "\\{\\{1}}\\{\\{2}}"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -507,3 +507,4 @@ omero_web_apps_config_set:
   omero.web.gallery.study_short_name:
   - key: "Name"
   - regex: "^(.*?)-.*?(.)$"
+  - template: "{{1}}{{2}}"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -416,7 +416,7 @@ omero_web_apps_config_set:
   omero.web.viewer.view: omero_iviewer.views.index
   omero.web.gallery.favicon: "https://idr.openmicroscopy.org/about/img/logos/favicon-idr.ico"
   omero.web.gallery.top_left_logo:
-    src: "http://idr.openmicroscopy.org/about/img/logos/logo-idr.svg"
+    src: "https://idr.openmicroscopy.org/about/img/logos/logo-idr.svg"
   omero.web.gallery.top_right_links:
     - text: "About"
       href: "https://idr.openmicroscopy.org/about/index.html"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -177,7 +177,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.3.0
 - omero-iviewer==0.7.1
-- omero-gallery==3.2.0a7
+- omero-gallery==3.2.0a8
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -504,3 +504,6 @@ omero_web_apps_config_set:
       query: "Sample Type:tissue"
       image: "https://idr.openmicroscopy.org/webgateway/render_image_region/5470164/0/0/?region=1024,1024,696,520"
   omero.web.gallery.title: "Welcome to IDR"
+  omero.web.gallery.study_short_name:
+  - key: "Name"
+  - regex: "^(.*?)-.*?(.)$"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -507,4 +507,4 @@ omero_web_apps_config_set:
   omero.web.gallery.study_short_name:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"
-    template: "\\{\\{1}}\\{\\{2}}"
+    template: "$1$2"


### PR DESCRIPTION
1 more config from https://github.com/ome/omero-gallery/pull/42

This regex uses the Study ```Name``` (e.g. ```idr0010-doil-dnadamage/screenA```) and produces e.g. ```idr0010A```.
See query at https://github.com/ome/omero-gallery/pull/42/files#r299405852
As the code might change there, best to wait for that PR to be merged before this one.