### PR TITLE
Postgres version

### DIFF
--- a/ansible/molecule/publicidr/molecule.yml
+++ b/ansible/molecule/publicidr/molecule.yml
@@ -75,6 +75,11 @@ provisioner:
     group_vars:
       omero-hosts:
         omero_server_systemd_require_network: False
+      database-hosts:
+        # Since the molecule test initialises a new OMERO database it fails:
+        # https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
+        # This isn't a problem on IDR production since it already exists
+        postgresql_package_version: "9.6.13"
 
 scenario:
   name: publicidr

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -100,8 +100,8 @@
   version: 1.1.0
 
 - name: openmicroscopy.postgresql
-  src: https://github.com/ome/ansible-role-postgresql/archive/6bf986821df5ada912080ae7bfa10e6e480b78b0.tar.gz
-  version: 6bf986821df5ada912080ae7bfa10e6e480b78b0
+  src: https://github.com/ome/ansible-role-postgresql
+  version: 3.2.0
 
 - src: openmicroscopy.python-pydata
   version: 1.1.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -99,8 +99,9 @@
 - src: openmicroscopy.openstack-volume-storage
   version: 1.1.0
 
-- src: openmicroscopy.postgresql
-  version: 3.0.1
+- name: openmicroscopy.postgresql
+  src: https://github.com/ome/ansible-role-postgresql/archive/6bf986821df5ada912080ae7bfa10e6e480b78b0.tar.gz
+  version: 6bf986821df5ada912080ae7bfa10e6e480b78b0
 
 - src: openmicroscopy.python-pydata
   version: 1.1.0


### PR DESCRIPTION
Pin Postgresql to 9.6.13 in molecule test to workaround https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929