### PR TITLE
Update Galaxy requirements

### DIFF
--- a/ansible/experimental-omero-web-addons.yml
+++ b/ansible/experimental-omero-web-addons.yml
@@ -4,7 +4,7 @@
 
   roles:
   # Needed for handlers
-  - role: openmicroscopy.omero-common
+  - role: ome.omero_common
 
   tasks:
 

--- a/ansible/idr-bastion.yml
+++ b/ansible/idr-bastion.yml
@@ -9,7 +9,7 @@
     {{ idr_environment | default('idr') }}-bastion-hosts
 
   roles:
-  - role: openmicroscopy.hosts-populate
+  - role: ome.hosts_populate
     hosts_populate_openstack_groups:
     - "{{ idr_environment | default('idr') }}-hosts"
     hosts_populate_regex_alias: "^[^-]+-(.+)"

--- a/ansible/idr-docker.yml
+++ b/ansible/idr-docker.yml
@@ -5,7 +5,7 @@
     {{ idr_environment | default('idr') }}-dockerworker-hosts
 
   roles:
-    - role: openmicroscopy.docker
+    - role: ome.docker
       # Upstream requires additional kubernetes configuration
       docker_install_upstream: False
       docker_use_ipv4_nic_mtu: True
@@ -31,8 +31,8 @@
     - volumes
 
   roles:
-  - role: openmicroscopy.versioncontrol-utils
-  - role: openmicroscopy.nfs-share
+  - role: ome.versioncontrol_utils
+  - role: ome.nfs_share
     nfs_shares:
       /data/mineotaur:
       - host: "*"

--- a/ansible/idr-downloads.yml
+++ b/ansible/idr-downloads.yml
@@ -11,7 +11,7 @@
 
   roles:
 
-  - role: openmicroscopy.rsync-server
+  - role: ome.rsync_server
     rsync_server_shares:
     - name: omero
       path: /data/OMERO

--- a/ansible/idr-dundee-nfs.yml
+++ b/ansible/idr-dundee-nfs.yml
@@ -9,7 +9,7 @@
     idr_mountpoint: /uod/idr
 
   roles:
-  - role: openmicroscopy.nfs-mount
+  - role: ome.nfs_mount
     nfs_share_mounts:
     - path: "{{ idr_mountpoint }}"
       location: idr-data.openmicroscopy.org:/uod/idr

--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -4,10 +4,10 @@
 
   roles:
 
-  - role: openmicroscopy.docker
+  - role: ome.docker
     docker_use_ipv4_nic_mtu: True
 
-  - role: openmicroscopy.anonymous-ftp
+  - role: ome.anonymous_ftp
     anonymous_ftp_incoming_data_dir: /data/idrftp-incoming
     anonymous_ftp_port: 32021
     anonymous_ftp_banner_text: |

--- a/ansible/idr-haproxy.yml
+++ b/ansible/idr-haproxy.yml
@@ -40,8 +40,8 @@
         }}
 
   roles:
-  - role: openmicroscopy.selinux-utils
-  - role: openmicroscopy.haproxy
+  - role: ome.selinux_utils
+  - role: ome.haproxy
     haproxy_cfg_template: "{{ playbook_dir }}/templates/haproxy.cfg.j2"
     # haproxy needs some special setup to log to a file
     haproxy_syslog_configure_udp: True

--- a/ansible/idr-local-users.yml
+++ b/ansible/idr-local-users.yml
@@ -5,7 +5,7 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
   roles:
-  - role: openmicroscopy.sudoers
+  - role: ome.sudoers
 #    sudoers_individual_commands:
-  - role: openmicroscopy.local-accounts
+  - role: ome.local_accounts
 #    local_accounts_create:

--- a/ansible/idr-networks.yml
+++ b/ansible/idr-networks.yml
@@ -6,12 +6,12 @@
 # other servers
 - hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
   roles:
-  - role: openmicroscopy.network-cloud-interfaces
+  - role: ome.network_cloud_interfaces
     network_cloud_interface_regex: '^eth.*'
 
 # All other hosts (e.g. those requiring NFS access on a separate network)
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
   roles:
-  - role: openmicroscopy.network-cloud-interfaces
+  - role: ome.network_cloud_interfaces
     network_cloud_interface_regex: '^eth.*'

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -16,7 +16,7 @@
 
   roles:
 
-  - role: openmicroscopy.nfs-share
+  - role: ome.nfs_share
     nfs_shares:
       /data/OMERO:
       - host: "*"
@@ -30,7 +30,7 @@
         options: 'ro'
 
   # Include restart handlers
-  - role: openmicroscopy.omero-common
+  - role: ome.omero_common
 
   tasks:
   # Lock down the read-write node in the read-only cluster
@@ -55,7 +55,7 @@
 
   roles:
   # Use the same paths as on the omeorreadwrite server to reduce confusion
-  - role: openmicroscopy.nfs-mount
+  - role: ome.nfs_mount
     nfs_share_mounts:
     - path: /data/OMERO-readonly
       location: "{{ omero_fileserver_host_ansible }}:/data/OMERO"
@@ -68,7 +68,7 @@
       opts: ro,soft
 
   # Include restart handlers
-  - role: openmicroscopy.omero-common
+  - role: ome.omero_common
 
   tasks:
 
@@ -183,6 +183,6 @@
     {{ idr_environment | default('idr') }}-omeroreadonly-hosts
 
   roles:
-  - role: openmicroscopy.omero-server
+  - role: ome.omero_server
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"

--- a/ansible/idr-omero-web.yml
+++ b/ansible/idr-omero-web.yml
@@ -4,9 +4,9 @@
 - hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
 
   roles:
-  - role: openmicroscopy.redis
-  - role: openmicroscopy.omero-web
-  - role: openmicroscopy.omero-web-apps
+  - role: ome.redis
+  - role: ome.omero_web
+  - role: ome.omero_web_apps
 
   # Vars are in group_vars/omero-hosts.yml
 

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -6,7 +6,7 @@
 - hosts: "{{ idr_environment | default('idr') }}-database-hosts"
 
   roles:
-  - role: openmicroscopy.postgresql
+  - role: ome.postgresql
 
   # tasks:
   # - name: postgres idr pg_stat_statements extension
@@ -43,16 +43,16 @@
 - hosts: "{{ idr_environment | default('idr') }}-omero-hosts"
 
   roles:
-  - role: openmicroscopy.basedeps
-  - role: openmicroscopy.cli-utils
-  - role: openmicroscopy.versioncontrol-utils
-  - role: openmicroscopy.python-pydata
-  - role: openmicroscopy.analysis-tools
+  - role: ome.basedeps
+  - role: ome.cli_utils
+  - role: ome.versioncontrol_utils
+  - role: ome.python_pydata
+  - role: ome.analysis_tools
 
 
 - hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
 
   roles:
-  - role: openmicroscopy.omero-server
+  - role: ome.omero_server
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -3,7 +3,7 @@
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
 
   roles:
-  - role: openmicroscopy.deploy_archive
+  - role: ome.deploy_archive
     become: yes
 
   tasks:

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -15,7 +15,7 @@
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
   roles:
-  - role: openmicroscopy.selinux-utils
+  - role: ome.selinux_utils
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
 
@@ -72,8 +72,8 @@
   # Default to a self-signed certificate
   # To use production certificates see
   # https://github.com/openmicroscopy/ansible-role-ssl-certificate/blob/0.2.0/README.md
-  - role: openmicroscopy.ssl-certificate
-  - role: openmicroscopy.nginx-proxy
+  - role: ome.ssl_certificate
+  - role: ome.nginx_proxy
 
   handlers:
   - name: restart nginx when certificates changed

--- a/ansible/idr-reboot-if-kernel.yml
+++ b/ansible/idr-reboot-if-kernel.yml
@@ -11,7 +11,7 @@
     {{ idr_environment | default('idr') }}-hosts
     !bastion-hosts
   roles:
-  - role: openmicroscopy.reboot-server
+  - role: ome.reboot_server
     reboot_server_timeout: 0
 
 
@@ -21,5 +21,5 @@
     {{ idr_environment | default('idr') }}-hosts
     &bastion-hosts
   roles:
-  - role: openmicroscopy.reboot-server
+  - role: ome.reboot_server
     reboot_server_timeout: 0

--- a/ansible/idr-reset-users-groups.yml
+++ b/ansible/idr-reset-users-groups.yml
@@ -28,7 +28,7 @@
     register: random_root_pass
 
   roles:
-  - openmicroscopy.omero-user
+  - role: ome.omero_user
 
   post_tasks:
 

--- a/ansible/idr-upgrade-dist.yml
+++ b/ansible/idr-upgrade-dist.yml
@@ -4,7 +4,7 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-hosts
   roles:
-  - role: openmicroscopy.upgrade-distpackages
+  - role: ome.upgrade_distpackages
   # Ideally we should auto-reboot, but if the SSH proxy host is rebooted
   # this breaks connections to all the backend servers and ansible may hang.
   # Instead all nodes must be rebooted manually after a kernel upgrade (be

--- a/ansible/k8s-k8sproxy.yml
+++ b/ansible/k8s-k8sproxy.yml
@@ -47,14 +47,14 @@
 
   roles:
 
-  - role: openmicroscopy.selinux-utils
+  - role: ome.selinux_utils
 
   # Default to a self-signed certificate, to use production certificates see
   # https://github.com/openmicroscopy/ansible-role-ssl-certificate/blob/0.2.0/README.md
-  - role: openmicroscopy.ssl-certificate
+  - role: ome.ssl_certificate
 
   # TODO: Restart haproxy when certificate changes
-  - role: openmicroscopy.haproxy
+  - role: ome.haproxy
     haproxy_cfg_template: "{{ playbook_dir }}/templates/k8sproxy-haproxy.cfg.j2"
     # haproxy needs some special setup to log to a file
     haproxy_syslog_configure_udp: True

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -185,7 +185,7 @@
     when: _td_agent_st.stat.exists
 
   roles:
-  - role: openmicroscopy.fluentd
+  - role: ome.fluentd
 
   vars:
     fluentd_server_address: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -4,12 +4,12 @@
     {{ idr_environment | default('idr') }}-hosts
 
   roles:
-  - role: openmicroscopy.prometheus-node
+  - role: ome.prometheus_node
 
 
 - hosts: "{{ idr_environment | default('idr') }}-database-hosts"
   roles:
-  - role: openmicroscopy.prometheus-postgres
+  - role: ome.prometheus_postgres
     prometheus_postgres_dbname: idr
     prometheus_postgres_query_filenames:
     - queries-default.yml
@@ -21,18 +21,18 @@
 
   roles:
 
-  - role: openmicroscopy.prometheus-jmx
+  - role: ome.prometheus_jmx
 
   # Needed for handlers
-  - role: openmicroscopy.omero-common
+  - role: ome.omero_common
 
-  - role: openmicroscopy.omero-prometheus-exporter
+  - role: ome.omero_prometheus_exporter
     omero_prometheus_exporter_omero_user: public
     omero_prometheus_exporter_omero_password: "{{ idr_secret_public_password | default('public') }}"
     # Disable the extra count queries to reduce load
     omero_prometheus_exporter_counts_query_files: []
 
-  - role: openmicroscopy.omero-web-django-prometheus
+  - role: ome.omero_web_django_prometheus
 
   tasks:
 
@@ -58,17 +58,17 @@
 
   roles:
 
-  - role: openmicroscopy.cadvisor
+  - role: ome.cadvisor
 
 
 - hosts: "{{ idr_environment | default('idr') }}-management-hosts"
 
   roles:
 
-  - role: openmicroscopy.docker
+  - role: ome.docker
     docker_use_ipv4_nic_mtu: True
 
-  - role: openmicroscopy.prometheus
+  - role: ome.prometheus
     prometheus_docker_network: monitoring
 
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"

--- a/ansible/management.yml
+++ b/ansible/management.yml
@@ -9,8 +9,8 @@
 - hosts: "{{ idr_environment | default('idr') }}-management-hosts"
 
   roles:
-  - role: openmicroscopy.basedeps  # munin requires EPEL
-  - role: openmicroscopy.munin
+  - role: ome.basedeps  # munin requires EPEL
+  - role: ome.munin
     munin_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
     munin_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
     munin_slack_username: "{{ idr_environment | default('idr') }} Munin Notification"
@@ -56,8 +56,8 @@
     {{ idr_environment | default('idr') }}-dockerworker-hosts
     {{ idr_environment | default('idr') }}-management-hosts
   roles:
-  - role: openmicroscopy.basedeps  # munin-node requires EPEL
-  - role: openmicroscopy.munin-node
+  - role: ome.basedeps  # munin-node requires EPEL
+  - role: ome.munin_node
     munin_node_allowed_ips:
     - '^192\.168\.\d+\.\d+$'
 
@@ -79,7 +79,7 @@
       omero_logmonitor_server_name: "{{ short_hostname.stdout }}"
 
   roles:
-  - role: openmicroscopy.omero-logmonitor
+  - role: ome.omero_logmonitor
     omero_logmonitor_slack_token: "{{ idr_secret_omero_logmonitor_slack_token | default(None) }}"
     omero_logmonitor_slack_channel: idr-logs-{{ idr_environment | default('idr') }}
 
@@ -90,7 +90,7 @@
     {{ idr_environment | default('idr') }}-dockerworker-hosts
 
   roles:
-  - role: openmicroscopy.docker-slack-notifier
+  - role: ome.docker_slack_notifier
     docker_slack_notifier_channel: "#idr-logs-{{ idr_environment | default('idr') }}"
     docker_slack_notifier_username: "{{ ansible_hostname }}"
     docker_slack_notifier_icon: ":docker:"

--- a/ansible/openstack-create-ftp.yml
+++ b/ansible/openstack-create-ftp.yml
@@ -75,7 +75,7 @@
   ############################################################
   # Volumes
 
-  - role: openmicroscopy.openstack-volume-storage
+  - role: ome.openstack_volume_storage
     openstack_volume_size: "{{ idr_environment_ftp_size | default(15000) }}"
     openstack_volume_vmname: "{{ idr_environment_idr }}-ftp"
     openstack_volume_name: ftpdata

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -100,21 +100,21 @@
     ############################################################
     # IDR Volumes
 
-    - role: openmicroscopy.openstack-volume-storage
+    - role: ome.openstack_volume_storage
       openstack_volume_size: 500
       openstack_volume_vmname: "{{ idr_environment_idr }}-database"
       openstack_volume_name: db
       openstack_volume_device: /dev/vdb
       openstack_volume_source: "{{ idr_volume_database_db_src }}"
 
-    - role: openmicroscopy.openstack-volume-storage
+    - role: ome.openstack_volume_storage
       openstack_volume_size: 1000
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdb
       openstack_volume_source: "{{ idr_volume_omero_data_src }}"
 
-    - role: openmicroscopy.openstack-volume-storage
+    - role: ome.openstack_volume_storage
       openstack_volume_size: 100
       openstack_volume_vmname: "{{ idr_environment_idr }}-proxy"
       openstack_volume_name: nginxcache
@@ -141,7 +141,7 @@
     ############################################################
     # Management Volume (do not copy when upgrading)
 
-    - role: openmicroscopy.openstack-volume-storage
+    - role: ome.openstack_volume_storage
       openstack_volume_size: 100
       openstack_volume_vmname: "{{ idr_environment_idr }}-management"
       openstack_volume_name: data

--- a/ansible/os-idr-volumes.yml
+++ b/ansible/os-idr-volumes.yml
@@ -4,20 +4,20 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-database-hosts
   roles:
-  - role: openmicroscopy.storage-volume-initialise
+  - role: ome.storage_volume_initialise
     storage_volume_initialise_device: "{{ database_db_vol_dev | default('/dev/vdb') }}"
     storage_volume_initialise_mount: /var/lib/pgsql
 
 - hosts: >
     {{ idr_environment | default('idr') }}-omeroreadwrite-hosts
   roles:
-  - role: openmicroscopy.storage-volume-initialise
+  - role: ome.storage_volume_initialise
     storage_volume_initialise_device: "{{ omero_data_vol_dev | default('/dev/vdb') }}"
     storage_volume_initialise_mount: /data
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
   roles:
-  - role: openmicroscopy.storage-volume-initialise
+  - role: ome.storage_volume_initialise
     storage_volume_initialise_device: "{{ gateway_nginxcache_vol_dev | default('/dev/vdb') }}"
     storage_volume_initialise_mount: /var/cache/nginx
 
@@ -25,6 +25,6 @@
 - hosts: >
     {{ idr_environment | default('idr') }}-data-hosts
   roles:
-  - role: openmicroscopy.storage-volume-initialise
+  - role: ome.storage_volume_initialise
     storage_volume_initialise_device: "{{ data_vol_dev | default('/dev/vdb') }}"
     storage_volume_initialise_mount: /data

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,143 +6,131 @@
 # TODO: check ordering of these dependencies to ensure nested dependencies
 # are managed by this file and not the role
 
-- src: openmicroscopy.analysis-tools
-  version: 1.0.0
-
-- src: openmicroscopy.anonymous-ftp
-  version: 0.1.1
-
-- src: openmicroscopy.basedeps
-  version: 1.0.0
-
-- src: openmicroscopy.cadvisor
-  version: 0.2.0
-
-- src: openmicroscopy.cli-utils
-  version: 1.0.0
-
-- src: openmicroscopy.deploy_archive
-  version: 0.1.2
-
-- src: openmicroscopy.docker
-  version: 2.3.0
-
-- src: openmicroscopy.docker-tools
-  version: 1.0.0
-
-- src: openmicroscopy.haproxy
-  version: 3.2.0
-
-- src: openmicroscopy.hosts-populate
-  version: 0.2.0
-
-- src: openmicroscopy.ice
-  version: 2.1.1
-
-- src: openmicroscopy.java
-  version: 2.0.1
-
-- src: openmicroscopy.local-accounts
+- src: ome.analysis_tools
   version: 1.0.1
 
-- src: openmicroscopy.logrotate
-  version: 1.0.0
+- src: ome.anonymous_ftp
+  version: 0.1.2
 
-- src: openmicroscopy.lvm-partition
+- src: ome.basedeps
   version: 1.1.0
 
-- src: openmicroscopy.munin
-  version: 1.1.3-openmicroscopy1
+- src: ome.cadvisor
+  version: 0.3.1
 
-- src: openmicroscopy.munin-node
-  version: 1.2.1-openmicroscopy1
-
-- src: openmicroscopy.network-cloud-interfaces
-  version: 1.2.1
-
-- src: openmicroscopy.nfs-mount
+- src: ome.cli_utils
   version: 1.1.0
 
-- src: openmicroscopy.nfs-share
+- src: ome.deploy_archive
+  version: 0.1.3
+
+- src: ome.docker
+  version: 3.0.2
+
+- src: ome.docker_tools
+  version: 1.0.1
+
+- src: ome.haproxy
+  version: 3.2.2
+
+- src: ome.hosts_populate
+  version: 0.2.1
+
+- src: ome.ice
+  version: 3.0.0
+
+- src: ome.java
+  version: 2.0.3
+
+- src: ome.local_accounts
   version: 1.0.2
 
-- src: openmicroscopy.nginx
-  version: 1.0.0
+- src: ome.logrotate
+  version: 1.0.1
 
-# Updated nginx-proxy role requires ome.nginx
-- name: ome.nginx
-  src: openmicroscopy.nginx
-  version: 1.0.0
+- src: ome.lvm_partition
+  version: 1.1.1
 
-- name: openmicroscopy.nginx-proxy
-  src: https://github.com/ome/ansible-role-nginx-proxy
+- src: ome.munin
+  version: 1.1.3-openmicroscopy1
+
+- src: ome.munin_node
+  version: 1.2.1-openmicroscopy1
+
+- src: ome.network_cloud_interfaces
+  version: 1.2.2
+
+- src: ome.nfs_mount
+  version: 1.2.1
+
+- src: ome.nfs_share
+  version: 1.0.3
+
+- src: ome.nginx
+  version: 1.1.1
+
+- src: ome.nginx_proxy
   version: 1.11.0
 
-- src: openmicroscopy.omero-common
-  version: 0.3.0
+- src: ome.omero_common
+  version: 0.3.2
 
-- src: openmicroscopy.omego
-  version: 0.1.1
+- src: ome.omego
+  version: 0.1.3
 
-- src: openmicroscopy.omero-logmonitor
-  version: 2.1.0
+- src: ome.omero_logmonitor
+  version: 2.1.1
 
-- src: openmicroscopy.omero-python-deps
-  version: 1.1.0
-
-- src: openmicroscopy.omero-server
-  version: 2.0.5
-
-- src: openmicroscopy.omero-user
-  version: 0.1.1
-
-- src: openmicroscopy.omero-web
+- src: ome.omero_python_deps
   version: 2.0.1
 
-- src: openmicroscopy.omero-web-apps
-  version: 0.1.1
+- src: ome.omero_server
+  version: 2.0.6
 
-- src: openmicroscopy.openstack-volume-storage
-  version: 1.1.0
+- src: ome.omero_user
+  version: 0.1.2
 
-- name: openmicroscopy.postgresql
-  src: https://github.com/ome/ansible-role-postgresql
+- src: ome.omero_web
+  version: 2.0.2
+
+- src: ome.omero_web_apps
+  version: 0.1.2
+
+- src: ome.openstack_volume_storage
+  version: 1.1.1
+
+- src: ome.postgresql
   version: 3.2.0
 
-- src: openmicroscopy.python-pydata
-  version: 1.1.0
+- src: ome.python_pydata
+  version: 1.1.1
 
-- src: openmicroscopy.reboot-server
-  version: 0.1.1
+- src: ome.reboot_server
+  version: 0.1.2
 
-- src: openmicroscopy.redis
-  version: 1.1.0
+- src: ome.redis
+  version: 1.1.1
 
-- src: openmicroscopy.rsync-server
-  version: 1.0.0
+- src: ome.rsync_server
+  version: 1.0.1
 
-- src: openmicroscopy.selinux-utils
+- src: ome.selinux_utils
   version: 1.0.3
 
-# Updated nginx-proxy role requires ome.selinux_utils
-- name: ome.selinux_utils
-  src: openmicroscopy.selinux-utils
-  version: 1.0.3
+- src: ome.ssl_certificate
+  version: 0.3.2
 
-- src: openmicroscopy.ssl-certificate
-  version: 0.3.0
+- src: ome.storage_volume_initialise
+  version: 1.0.1
 
-- src: openmicroscopy.storage-volume-initialise
-  version: 1.0.0
+- src: ome.sudoers
+  version: 1.0.1
 
-- src: openmicroscopy.sudoers
-  version: 1.0.0
+- src: ome.upgrade_distpackages
+  version: 1.1.1
 
-- src: openmicroscopy.upgrade-distpackages
-  version: 1.1.0
-
-- src: openmicroscopy.versioncontrol-utils
-  version: 1.0.0
+- src: ome.versioncontrol_utils
+  version: 1.0.2
 
 
 ######################################################################
@@ -180,34 +168,26 @@
 ######################################################################
 # External development roles
 
-- name: openmicroscopy.docker-slack-notifier
-  src: https://github.com/openmicroscopy/ansible-role-docker-slack-notifier/archive/0.0.2.tar.gz
-  version: 0.0.2
+- src: ome.docker_slack_notifier
+  version: 0.0.4
 
-- name: openmicroscopy.fluentd
-  src: https://github.com/openmicroscopy/ansible-role-fluentd/archive/0.2.1.tar.gz
+- src: ome.fluentd
+  version: 0.2.2
+
+- src: ome.omero_prometheus_exporter
   version: 0.2.1
 
-- name: openmicroscopy.omero-prometheus-exporter
-  src: https://github.com/openmicroscopy/ansible-role-omero-prometheus-exporter/archive/0.1.0.tar.gz
-  version: 0.1.0
+- src: ome.omero_web_django_prometheus
+  version: 0.2.1
 
-- name: openmicroscopy.omero-web-django-prometheus
-  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
-  version: 0.2.0
+- src: ome.prometheus
+  version: 0.3.1
 
-- name: openmicroscopy.prometheus
-  src: openmicroscopy.ansible-role-prometheus
-  version: 0.3.0
+- name: ome.prometheus_jmx
+  version: 0.2.1
 
-- name: openmicroscopy.prometheus-jmx
-  src: openmicroscopy.ansible-role-prometheus-jmx
-  version: 0.2.0
+- src: ome.prometheus_node
+  version: 0.2.1
 
-- name: openmicroscopy.prometheus-node
-  src: openmicroscopy.ansible-role-prometheus-node
-  version: 0.2.0
-
-- name: openmicroscopy.prometheus-postgres
-  src: openmicroscopy.ansible-role-prometheus-postgres
-  version: 0.2.0
+- src: ome.prometheus_postgres
+  version: 0.2.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -94,7 +94,7 @@
   version: 2.0.2
 
 - src: ome.omero_web_apps
-  version: 0.1.2
+  version: 0.2.0
 
 - src: ome.openstack_volume_storage
   version: 1.1.1

--- a/ansible/roles/kubernetes/meta/main.yml
+++ b/ansible/roles/kubernetes/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   galaxy_tags: []
 
 dependencies:
-- src: openmicroscopy.selinux-utils
+- role: ome.selinux_utils

--- a/ansible/roles/kubernetes/tests/requirements.yml
+++ b/ansible/roles/kubernetes/tests/requirements.yml
@@ -1,2 +1,2 @@
-- src: openmicroscopy.docker
-- src: openmicroscopy.selinux-utils
+- src: ome.docker
+- src: ome.selinux_utils


### PR DESCRIPTION
All Galaxy roles have been migrated to the Galaxy OME organization. This updates the IDR requirements file to use these new roles. Changes should be limited to renaming and have no functional impact.

Most roles are bumped to a patch release, usually the one associated with the role migration, which should be harmless. Below is the list of minor/major versions bumps:

- ome.basedeps: 1.0.0 -> 1.1.0 (Ubuntu 18.04 support)
- ome.cadvisor 0.2.0 -> 0.3.1 (Use official binary)
- ome.cli_utils: 1.0.0 -> 1.1.0 (add zsh)
- ome.docker: 2.3.0 -> 3.0.2 (removed support for distribution Docker)
- ome.ice: 2.1.1 -> 3.0.0 (drop support for Ice 3.5)
- ome.nfs_mount: 1.1.0 -> 1.2.1 (manage multiple versions of NFS)
- ome.nginx: 1.0.0 -> 1.1.1 (allow to set nginx_version)
- ome.omero_python_deps: 1.1.0 -> 2.0.1 (remove scipy)
- ome.omero_prometheus_exporter: 0.1.0 -> 0.2.1 (role renaming)

Most of these changes should be additive. @manics do you foresee any issue with bumping `ome.docker` and `ome.cadvisor`?