### PR TITLE
Bump ome.munin_node requirements to 1.2.1-openmicroscopy2

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -55,7 +55,7 @@
   version: 1.1.3-openmicroscopy1
 
 - src: ome.munin_node
-  version: 1.2.1-openmicroscopy1
+  version: 1.2.1-openmicroscopy2
 
 - src: ome.network_cloud_interfaces
   version: 1.2.2


### PR DESCRIPTION
Follow-up of #201 

With this role version, it should be possible to deploy IDR using a Python 3 environment. Tested while redeploying `test70`