### PR TITLE
Install testinfra 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 install:
-  - pip install "ome-ansible-molecule<0.5"
+  - pip install "ome-ansible-molecule<0.5" testinfra==2.1.0
 
 script:
   # TODO: molecule will only run ansible-lint on the target playbook,


### PR DESCRIPTION
See https://github.com/philpep/testinfra/blob/2.1.0/CHANGELOG.rst

This release includes a fix for the socket tests with new verions of ss. This
version seems to have made it into the base iproute CentOS packages

See https://github.com/IDR/deployment/pull/204#issuecomment-532266520 for the initial bug report. This should fix the IPv6 socket listening tests and let Travis CI pass

Proposing to get this in as a quick fix. Potential next steps up for discussion:

- force the minimal `testinfra` version in the `ome-ansible-molecule` package
- bump to `molecule 2.22` which depends on a recent version of `testinfra` (might require other fixes)
- do not override `testinfra` but investigate  downgrading the version of `ss` installed by `iproute` in the `prepare.yml` playbook
