### PR TITLE
Do not assign floating IP on VM creation

### DIFF
--- a/ansible/openstack-create-ftp.yml
+++ b/ansible/openstack-create-ftp.yml
@@ -59,7 +59,6 @@
     idr_vm_name: "{{ idr_environment_idr }}-ftp"
     idr_vm_image: "{{ vm_image }}"
     idr_vm_flavour: "{{ vm_flavour }}"
-    idr_vm_assign_floating_ip: True
     idr_vm_bastion: True
     idr_vm_extra_groups:
     - "{{ idr_environment_idr }}-ftp-hosts"

--- a/ansible/openstack-create-k8s.yml
+++ b/ansible/openstack-create-k8s.yml
@@ -139,7 +139,6 @@
       idr_vm_flavour: "{{ vm_flavour }}"
       #idr_vm_proxy: True
       idr_vm_bastion: True
-      idr_vm_assign_floating_ip: True
       idr_vm_extra_groups:
       - "{{ idr_environment_idr }}-k8sproxy-hosts"
       - "{{ idr_environment_idr }}-hosts"

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -87,7 +87,6 @@
       idr_vm_flavour: "{{ vm_flavour }}"
       idr_vm_proxy: True
       idr_vm_bastion: True
-      idr_vm_assign_floating_ip: True
       idr_vm_networks:
       - net-name: "{{ idr_environment_idr }}"
       idr_vm_security_groups:

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -72,7 +72,7 @@ Ensure you can login to OpenStack from the command line using [an OpenStack RC f
 
     ansible-playbook -i localhost, --diff openstack-create-infrastructure.yml
 
-This playbook will create a set of VMs on the OpenStack cloud. You can
+This playbook will create a set of VMs on the OpenStack cloud. You must
 associate the proxy host to a floating IP either usin the OpenStack UI or via
 the `openstack` command-line interface:
 

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -73,7 +73,7 @@ Ensure you can login to OpenStack from the command line using [an OpenStack RC f
     ansible-playbook -i localhost, --diff openstack-create-infrastructure.yml
 
 This playbook will create a set of VMs on the OpenStack cloud. You must
-associate the proxy host to a floating IP either usin the OpenStack UI or via
+associate the proxy host to a floating IP either using the OpenStack UI or via
 the `openstack` command-line interface:
 
     $ openstack floating ip list

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -72,14 +72,18 @@ Ensure you can login to OpenStack from the command line using [an OpenStack RC f
 
     ansible-playbook -i localhost, --diff openstack-create-infrastructure.yml
 
+This playbook will create a set of VMs on the OpenStack cloud. You can
+associate the proxy host to a floating IP either usin the OpenStack UI or via
+the `openstack` command-line interface:
+
+    $ openstack floating ip list
+    $ openstack server add floating ip <proxy_server_name> <ip>
+
 Ensure this playbook successfully runs to completion before [deploying the IDR](deployment.md).
 
 Warning: At present the `nova` command may be used to [attach additional network interfaces to instances](https://github.com/IDR/ansible-role-openstack-idr-instance-network).
 `nova` does not support [`clouds.yaml`](http://docs.openstack.org/developer/os-client-config/).
 This will be fixed when the `openstack` command-line client supports this feature.
-
-Occasionally you may see misleading such as `Quota exceeded for resources: ['floatingip'].`
-If this happens manually associate a floating IP with the idr-proxy server, and re-run the playbook.
 
 
 ## Other platforms


### PR DESCRIPTION
Given the number of issues associated with this step, the floating IP association is migrated as a manual step post-provisioning.