### PR TITLE
Bump omero-mapr version to 0.3.2

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -169,7 +169,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- omero-mapr==0.3.0
+- omero-mapr==0.3.2
 - omero-iviewer==0.8.1
 - omero-gallery==3.2.0a8
 omero_web_apps_names:


### PR DESCRIPTION
Includes the two following bug fixes

- https://github.com/ome/omero-mapr/pull/50
- https://github.com/ome/omero-mapr/pull/44

Deployed on `test71`. In addition to executing the playbook, I had to wipe the `omerostatic` cache and reload `nginx`. I wonder whether we want to do that more systematically in the deployment playbooks

```
[sbesson@test71-proxy ~]$ sudo rm -rf /var/cache/nginx/omerostatic/
[sbesson@test71-proxy ~]$ sudo service nginx reload
Redirecting to /bin/systemctl reload nginx.service
```