### PR TITLE
OMERO.server virtualenv

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -51,6 +51,11 @@ omero_server_datadir_bioformatscache: /data/BioFormatsCache
 
 omero_server_systemd_limit_nofile: 16384
 
+omero_server_virtualenv: true
+omero_server_python_addons:
+- omero-cli-render==0.4.3
+- omero-metadata==0.4.1
+
 omero_server_config_set:
   omero.db.poolsize: 25
   omero.jvmcfg.heap_size.blitz: "24G"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -85,13 +85,13 @@
   version: 2.0.1
 
 - src: ome.omero_server
-  version: 2.0.6
+  version: 2.1.0
 
 - src: ome.omero_user
   version: 0.1.2
 
 - src: ome.omero_web
-  version: 2.0.2
+  version: 2.0.3
 
 - src: ome.omero_web_apps
   version: 0.2.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -85,13 +85,13 @@
   version: 2.0.1
 
 - src: ome.omero_server
-  version: 2.1.0
+  version: 2.1.1
 
 - src: ome.omero_user
   version: 0.1.2
 
 - src: ome.omero_web
-  version: 2.0.3
+  version: 2.0.4
 
 - src: ome.omero_web_apps
   version: 0.2.0


### PR DESCRIPTION
Switch to using a virtualenv for OMERO.server.
This also means the metadata and render plugins can be installed automatically.

Also a minor bump to omero-web