### PR TITLE
Add study-specific redirects to the download page

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -278,6 +278,10 @@ _nginx_proxy_sites:
     # Only add this CORS header to the default public site
     nginx_proxy_additional_directives:
     - "add_header Access-Control-Allow-Origin $allow_origin"
+    # Study redirects
+    - "if ($request_uri ~ /search/\\?query=Name:idr0065) {
+       return 302 /about/download.html;}"
+
 
   # This is a duplicate of the main OMERO.web proxy configuration, but with
   # cache-busting:


### PR DESCRIPTION
This study is scheduled for publication in an upcoming IDR release. As the publication went online, the raw data is available via Aspera. In the interim, this allows the link to redirect to the download page.

Deployed on `test71`. Proposing to deploy on `prod71` immediately and tag 
cf25e5a  as `IDR-0.7.1-1`. The commit will need reverting for `prod72` release.