### PR TITLE
omero-ws should use external not reserved omero hosts

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -35,7 +35,7 @@ nginx_proxy_upstream_servers:
   servers: "{{ omero_omeroreadonly_hosts_reserved | sort }}"
 - name: omeroreadonlywebsockets
   balance: ip_hash
-  servers: "{{ omero_omeroreadonly_hosts_reserved | map('regex_replace', '^(.*)$', '\\1:4065') | sort }}"
+  servers: "{{ omero_omeroreadonly_hosts_external | map('regex_replace', '^(.*)$', '\\1:4065') | sort }}"
 - name: omeroreadwrite
   servers: "{{ omero_omeroreadwrite_hosts }}"
 

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -21,15 +21,30 @@
 
   pre_tasks:
 
+
+
+  - name: Get all omeroreadonly IP
+    set_fact:
+      _omero_omeroreadonly_hosts: >-
+        {{
+          groups[idr_environment | default('idr') + '-omeroreadonly-hosts'] |
+          map('extract', hostvars,
+            ['ansible_' + (idr_net_iface | default('eth0')), 'ipv4', 'address']) | sort
+        }}
+
   - name: Get omero IP
     set_fact:
       omero_omeroreadonly_hosts_reserved: >-
         {{
-          (
-          groups[idr_environment | default('idr') + '-omeroreadonly-hosts'] |
-          map('extract', hostvars,
-            ['ansible_' + (idr_net_iface | default('eth0')), 'ipv4', 'address']) | sort
-          )[:idr_backend_reserved_offset]
+          _omero_omeroreadonly_hosts[:idr_backend_reserved_offset]
+        }}
+      omero_omeroreadonly_hosts_external: >-
+        {{
+          _omero_omeroreadonly_hosts[
+            ([
+              idr_backend_reserved_offset,
+              _omero_omeroreadonly_hosts | length - 1
+            ] | min):]
         }}
       omero_omeroreadwrite_hosts: >-
         {{


### PR DESCRIPTION
Noticed a mistake whilst looking into changing the load-balancing for web-sockets. Currently omero-ws is proxied to the omeroreadonly servers reserved for OMERO.web instead of the ones ddesigned for direct external connects.

Note yet deployed

This is some other undeployed change:
```
TASK [ome.nginx_proxy : nginx | proxy config] **********************************
--- before: /etc/nginx/conf.d/proxy-default.conf
+++ after: /Users/spli/.ansible/tmp/ansible-local-64735ngztx6__/tmpr26fg1l6/nginx-confd-proxy.j2
@@ -243,5 +243,6 @@

     add_header Access-Control-Allow-Origin $allow_origin;
     if ($request_uri ~ /search/\?query=Name:idr0065) { return 302 /about/download.html;}
+    if ($request_uri ~ /search/\?query=Name:idr0068) { return 302 /about/download.html;}

 }
```

The relevant change:
```
TASK [ome.nginx_proxy : nginx | proxy upstream servers] ************************
--- before: /etc/nginx/conf.d/proxy-upstream.conf
+++ after: /Users/spli/.ansible/tmp/ansible-local-64735ngztx6__/tmp8s4yivga/ngin
x-confd-proxy-upstream.j2
@@ -7,8 +7,8 @@
 }
 upstream omeroreadonlywebsockets {
   ip_hash;
-  server 192.168.72.6:4065;
-  server 192.168.72.7:4065;
+  server 192.168.72.8:4065;
+  server 192.168.72.9:4065;
 }
 upstream omeroreadwrite {
   server 192.168.72.5;
```