### PR TITLE
extcloud01: customisations and bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
     --exclude ./roles/kubernetes/
     --exclude ./vendor/
     --exclude ../kubespray/
+    --exclude idr-firewall.yml
     --exclude idr-kubernetes-apply.yml
     --exclude idr-reset-users-groups.yml
   - cd ansible; molecule test -s $SCENARIO

--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -4,6 +4,11 @@
 
 - include: idr-hosts.yml
 
+- include: idr-firewall.yml
+  # TODO: enable this on extcloud05
+  # Currently only enabled for VMWare temporary tenancy
+  when: 'idr_enable_iptables_firewall | default(false)'
+
 - include: idr-omero.yml
 - include: idr-omero-web.yml
 

--- a/ansible/idr-ebi-nfs.yml
+++ b/ansible/idr-ebi-nfs.yml
@@ -1,19 +1,15 @@
-# Self-contained Ansible playbook for setting up the Embassy IDR NFS shares
+# Setup Embassy IDR NFS shares
 - hosts: >
     {{ idr_environment | default('idr') }}-ebi-nfs
 
-  tasks:
+  roles:
 
-  - name: Mount NFS shares
-    become: yes
-    mount:
-      fstype: nfs
-      name: "{{ item.dst }}"
-      # Removed rsize=8192,wsize=8192, this should be auto-negotiated
-      opts: timeo=14,intr,nolock
-      src: "{{ item.src }}"
-      state: mounted
-    with_items: "{{ ebi_nfs_mounts | default([]) }}"
+  - role: ome.nfs_mount
+    nfs_version: 3
+    nfs_mount_opts: timeo=14,intr,nolock,ro
+    nfs_share_mounts: "{{ ebi_nfs_mounts }}"
+
+  tasks:
 
   - name: Create storage base directory
     become: yes

--- a/ansible/idr-firewall.yml
+++ b/ansible/idr-firewall.yml
@@ -1,0 +1,76 @@
+# Firewall configuration
+# The VMWare CentOS image has firewalld enabled by default
+
+- hosts: "{{ idr_environment | default('idr') }}-hosts"
+  tasks:
+
+    # This should allow all network traffic
+    - name: Disable firewalld
+      become: yes
+      service:
+        name: firewalld
+        state: stopped
+        enabled: no
+      when: iptables_raw_disable_firewalld | default(True)
+
+
+- hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
+
+  roles:
+
+    - role: ome.iptables_raw
+
+  tasks:
+    # Allow:
+    # - all established/related in/out
+    # - all internal localhost connections
+    # - all internal traffic
+    # - ICMP echo (ping)
+    # - ssh incoming connections
+    # - Public IDR ports
+    - name: Iptables ssh and related
+      become: yes
+      iptables_raw_25:
+        name: default_and_idr_external
+        keep_unmanaged: no
+        rules: |
+          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A INPUT -i lo -j ACCEPT
+          -A INPUT -p tcp -s 10.0.0.0/8 -j ACCEPT
+          -A INPUT -p udp -s 10.0.0.0/8 -j ACCEPT
+          -A INPUT -p tcp -s 192.168.0.0/16 -j ACCEPT
+          -A INPUT -p udp -s 192.168.0.0/16 -j ACCEPT
+          -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+          -A INPUT -p tcp -m multiport --dports {{ idr_external_tcp_ports | join(',' ) }} -j ACCEPT
+        state: present
+        # Highest priority
+        weight: 0
+
+    # Use a low priority REJECT rule so that clients can detect when
+    # they've been rejected
+    # The alternative of setting a default DROP policy will leave them
+    # hanging until they timeout, though this may be preferable for public
+    # servers:
+    # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
+    - name: Iptables default
+      become: yes
+      iptables_raw_25:
+        name: default_reject
+        rules: |
+          -A INPUT -j REJECT
+          -A FORWARD -j REJECT
+          -A OUTPUT -j ACCEPT
+        state: present
+        # Lowest priority
+        weight: 99
+
+  vars:
+    idr_external_tcp_ports:
+      - 80
+      - 443
+      - 873
+      - 4063
+      - 4064
+      - "14060:14079"

--- a/ansible/idr-networks.yml
+++ b/ansible/idr-networks.yml
@@ -8,6 +8,7 @@
   roles:
   - role: ome.network_cloud_interfaces
     network_cloud_interface_regex: '^eth.*'
+    when: 'idr_provision_networks | default(True)'
 
 # All other hosts (e.g. those requiring NFS access on a separate network)
 - hosts: >
@@ -15,3 +16,4 @@
   roles:
   - role: ome.network_cloud_interfaces
     network_cloud_interface_regex: '^eth.*'
+    when: 'idr_provision_networks | default(True)'

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -113,7 +113,7 @@
       cleanup: True
       env:
         OLDER_THAN_IN_DAYS: "{{ elasticsearch_expire_logs_days }}"
-        INTERVAL_IN_HOURS: 24
+        INTERVAL_IN_HOURS: "24"
       networks:
       - name: fluent-es-kb
       state: started
@@ -124,10 +124,10 @@
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
     fluentd_slack_channel: "idr-notify-{{ idr_environment | default('idr') }}"
     fluentd_elasticsearch_host: elasticsearch
-    fluentd_uid: 1010
+    fluentd_uid: "1010"
     elasticsearch_docker_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"
     elasticsearch_curator_docker_image: "openmicroscopy/elasticsearch-curator:5.4.1"
-    elasticsearch_expire_logs_days: 14
+    elasticsearch_expire_logs_days: "14"
     fluentd_docker_image: "openmicroscopy/fluentd:0.1.0"
     kibana_docker_image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
 

--- a/ansible/management-grafana.yml
+++ b/ansible/management-grafana.yml
@@ -12,7 +12,7 @@
       image: grafana/grafana:5.1.3
       env:
         # Enable anonymous login
-        GF_AUTH_ANONYMOUS_ENABLED: true
+        GF_AUTH_ANONYMOUS_ENABLED: "true"
       links:
       - prometheus:prometheus
       name: grafana

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -86,12 +86,14 @@
       - "{{ idr_environment | default('idr') + '-hosts' }}"
       port: 9100
       jobname: node-exporter
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     - groupname: blitz
       groups:
       - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
       port: 9180
       jobname: jmx-blitz
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     # TODO: indexer and pixeldata are currently broken (fail to start)on
     # metadata53 due to the readonly work. These two targets should be
@@ -114,6 +116,7 @@
       - "{{ idr_environment | default('idr') + '-dockerworker-hosts' }}"
       port: 9280
       jobname: cadvisor-docker
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     # TODO: may need to split this into two roles, one for general stats
     # and one for detailed statement performance metrics
@@ -122,6 +125,7 @@
       - "{{ idr_environment | default('idr') + '-database-hosts' }}"
       port: 9187
       jobname: postgres-exporter
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     - groupname: omero-web
       groups:
@@ -129,12 +133,14 @@
       port: 80
       jobname: django
       metrics_path: /django_prometheus/metrics
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     - groupname: omero-sessions
       groups:
       - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
       port: 9449
       jobname: omero-sessions
+      iface: "{{ idr_net_iface | default('eth0') }}"
 
     prometheus_http_2xx_internal_targets: >
       {{

--- a/ansible/management.yml
+++ b/ansible/management.yml
@@ -82,16 +82,3 @@
   - role: ome.omero_logmonitor
     omero_logmonitor_slack_token: "{{ idr_secret_omero_logmonitor_slack_token | default(None) }}"
     omero_logmonitor_slack_channel: idr-logs-{{ idr_environment | default('idr') }}
-
-
-# Docker slack notifications
-- hosts: >
-    {{ idr_environment | default('idr') }}-dockermanager-hosts
-    {{ idr_environment | default('idr') }}-dockerworker-hosts
-
-  roles:
-  - role: ome.docker_slack_notifier
-    docker_slack_notifier_channel: "#idr-logs-{{ idr_environment | default('idr') }}"
-    docker_slack_notifier_username: "{{ ansible_hostname }}"
-    docker_slack_notifier_icon: ":docker:"
-    docker_slack_notifier_token: "{{ idr_secret_management_slack_webhook | default(None) }}"

--- a/ansible/molecule/ftp/molecule.yml
+++ b/ansible/molecule/ftp/molecule.yml
@@ -56,6 +56,21 @@ scenario:
     - dependency
   converge_sequence:
     - converge
+  # lint needs dependency for iptables_raw_25 module
+  # Although it's not used by the ftp deployment it's still automatically
+  # linted
+  test_sequence:
+    - destroy
+    - dependency
+    - lint
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - destroy
 
 verifier:
   name: testinfra

--- a/ansible/molecule/publicidr/molecule.yml
+++ b/ansible/molecule/publicidr/molecule.yml
@@ -87,6 +87,21 @@ scenario:
     - dependency
   converge_sequence:
     - converge
+  # lint needs dependency for iptables_raw_25 module
+  # Fixed in newer molecule: https://github.com/ansible/molecule/pull/2215
+  # https://github.com/ansible/molecule/blob/2.19/molecule/scenario.py#L63-L74
+  test_sequence:
+    - destroy
+    - dependency
+    - lint
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - destroy
 
 verifier:
   name: testinfra

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -175,9 +175,6 @@
 ######################################################################
 # External development roles
 
-- src: ome.docker_slack_notifier
-  version: 0.0.4
-
 - src: ome.fluentd
   version: 0.2.2
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -75,8 +75,9 @@
 - src: ome.nginx
   version: 1.1.1
 
-- src: ome.nginx_proxy
-  version: 1.11.0
+- name: ome.nginx_proxy
+  src: https://github.com/manics/ansible-role-nginx-proxy.git
+  version: 178d379f964a79813d702a51c986f835449631fe
 
 - src: ome.omero_common
   version: 0.3.2

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -39,6 +39,9 @@
 - src: ome.ice
   version: 3.0.0
 
+- src: ome.iptables_raw
+  version: 0.2.1
+
 - src: ome.java
   version: 2.0.3
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -60,6 +60,9 @@
 - src: ome.network_cloud_interfaces
   version: 1.2.2
 
+- src: ome.network
+  version: 1.1.3
+
 - src: ome.nfs_mount
   version: 1.2.1
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -75,9 +75,8 @@
 - src: ome.nginx
   version: 1.1.1
 
-- name: ome.nginx_proxy
-  src: https://github.com/manics/ansible-role-nginx-proxy.git
-  version: 178d379f964a79813d702a51c986f835449631fe
+- src: ome.nginx_proxy
+  version: 1.12.1
 
 - src: ome.omero_common
   version: 0.3.2


### PR DESCRIPTION
Changes for extcloud01:
- added customisations for things like network interfaces (default unchanged)
- added a firewall (disabled by default but we should consider enabling it on the next prod server too)
- NFS config uses the role and private variables (this is a change relative to `prod73` but should've been done ages ago)
- Fixed SELinux permissions on Nginx cache, requires https://github.com/ome/ansible-role-nginx-proxy/pull/27