### PR TITLE
firewall: be explicit about hosts, exclude ftp

### DIFF
--- a/ansible/idr-firewall.yml
+++ b/ansible/idr-firewall.yml
@@ -1,9 +1,8 @@
 # Firewall configuration
 
 - hosts: >
-    {{ idr_environment | default('idr') }}-hosts
-    !bastion-hosts
-    !management-hosts
+    {{ idr_environment | default('idr') }}-database-hosts
+    {{ idr_environment | default('idr') }}-omero-hosts
 
   roles:
     - role: ome.iptables_raw
@@ -28,7 +27,7 @@
 #     {{ idr_environment | default('idr') }}-management-hosts
 
 
-- hosts: "{{ idr_environment | default('idr') }}-bastion-hosts"
+- hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
 
   roles:
     - role: ome.iptables_raw


### PR DESCRIPTION
Minor fix to which hosts are targetted by the firewall. idr-ftp shouldn't be modified because it's runnign Docker which does it's own iptables management.