### PR TITLE
Add ebi-migration page

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -374,13 +374,13 @@ idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 ######################################################################
 # Static webpages (/about) on proxy
 
-idr_openmicroscopy_org_version: 2020.03.02
+idr_openmicroscopy_org_version: 2020.03.11
 deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
 deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
 # Optional checksum. It should be safe to omit as long as you never
 # overwrite an existing archive. This should not be a problem when using
 # versioned directories.
-deploy_archive_sha256: 32cb79822c46a931aaffc29a2b594d2f12a5299730d3476d232ec010ed42dc20
+deploy_archive_sha256: 48f7ae97f58b9a9887f52d206dbb732a885964b3600c910be1f107bd264f3ca1
 deploy_archive_symlink: /srv/www/html
 idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
 idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"


### PR DESCRIPTION
Adds a holding page where idr-analysis can be redirected

Deployed to prod80a, DNS updated