### PR TITLE
Consume 0.6.3 release of IDR Bio-Formats

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -21,7 +21,7 @@ idr_bf_components:
   - formats-api
   - formats-bsd
   - formats-gpl
-idr_bf_release: "0.6.1"
+idr_bf_release: "0.6.3"
 idr_bf_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven/idr"
 
 ice_install_devel: false


### PR DESCRIPTION
This patch release includes the MetaXpress fix required for idr0081

To be tested in a testing resource first to confirm memo files are not invalidated. Current target release: `prod82`