### PR TITLE
Add omero-upload as addon install

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -67,6 +67,7 @@ omero_server_systemd_limit_nofile: 16384
 omero_server_python_addons:
 - omero-cli-render==0.5.0
 - omero-metadata==0.5.0
+- omero-upload==0.3.0
 
 omero_server_config_set:
   omero.db.poolsize: 25


### PR DESCRIPTION
Deployed successfully on the server. 

This is in prep of using https://github.com/ome/omero-upload/blob/18277a7669d37296ecb49f6e8102ec89b99ca0a8/src/omero_upload/library.py#L76-L88 method for in-place import of attachments to IDR.

cc @sbesson 