### PR TITLE
Add study-level redirects for figures of idr0083

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -236,9 +236,15 @@ nginx_proxy_redirect_map:
 - match: ~/pgpc
   dest: /webclient/?show=screen-1151
 
+- match: /study/idr0083/figure/4i
+  dest: /webclient/img_detail/9822151/?dataset=10201&x=34105&y=84808&zm=25&c=1|318:9927$808080&m=g
+  dest: /webclient/?show=screen-1151
+- match: /study/idr0083/figure/4r
+  dest: /webclient/img_detail/9822152/?dataset=10201&x=80560&y=77440&zm=66&c=1|495:9204$808080&m=g
+
 nginx_proxy_redirect_map_locations:
 # TODO: change to 301 when we're happy
-- location: "~ ^/(mito|tara|pgpc)($|/)"
+- location: "~ ^/(mito|tara|pgpc|study)($|/)"
   code: 302
 
 # "= /" has higher priority than "/" in the proxy config

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -238,7 +238,6 @@ nginx_proxy_redirect_map:
 
 - match: /study/idr0083/figure/4i
   dest: /webclient/img_detail/9822151/?dataset=10201&x=34105&y=84808&zm=25&c=1|318:9927$808080&m=g
-  dest: /webclient/?show=screen-1151
 - match: /study/idr0083/figure/4r
   dest: /webclient/img_detail/9822152/?dataset=10201&x=80560&y=77440&zm=66&c=1|495:9204$808080&m=g
 


### PR DESCRIPTION
These URLs pointing to figure panels can be reused in tweets and press releases

Changes have been applied manually in production on `prod80a` and `prod80b` so the main test here is to run the `idr-proxy.yml` in check-mode against either or both servers and test there is no diff (or only whitespaces)