### PR TITLE
Add compound to the list of image attributes searchable by IDR gallery

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -537,6 +537,7 @@ omero_web_apps_config_set:
   omero.web.gallery.filter_mapr_keys:
   - "antibody"
   - "cellline"
+  - "compound"
   - "gene"
   - "phenotype"
   - "sirna"


### PR DESCRIPTION
Noticed while preparing the talk for the 2020 Community meeting.

Given the importance of this biomolecular annotation for compound screens as well as the work engaged to rationalize its ontology, this PR proposes to add the category to the top-level search box.

Target: `prod83`