### PR TITLE
Revert "Allocate extra server to web, remove from 4064"

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -380,7 +380,7 @@ nginx_proxy_streams: >
 #   external OMERO API access. At least one backend will always be
 #   assigned as an external proxy; if necessary it will overlap with
 #   OMERO.web
-idr_backend_reserved_offset: 3
+idr_backend_reserved_offset: 2
 idr_haproxy_frontend_omero_offset: 14060
 idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 


### PR DESCRIPTION
This reverts commit d28d764426e4c1c915c995f27d3cfadffcf9b189.

Reverts #233

```diff
TASK [ome.haproxy : Copy HAProxy configuration in place.] **********************
--- before: /etc/haproxy/haproxy.cfg
+++ after: /Users/spli/.ansible/tmp/ansible-local-27293uyiv4yzj/tmpo4wkthkz/haproxy.cfg.j2
@@ -35,12 +35,20 @@
     option tcplog
     timeout client 10m
     log 127.0.0.1 local3
+frontend omero4064-1
+    bind *:14061
+    mode tcp
+    default_backend omero4064-1
+    option tcplog
+    timeout client 10m
+    log 127.0.0.1 local3


 backend omero4064
     mode tcp
     balance source
     option tcplog
+    server omero4064-192_168_101_17 192.168.101.17:4064 check
     server omero4064-192_168_101_18 192.168.101.18:4064 check
     timeout connect 10s
     timeout server 10m
@@ -49,6 +57,13 @@
     mode tcp
     balance source
     option tcplog
+    server omero4064-192_168_101_17 192.168.101.17:4064 check
+    timeout connect 10s
+    timeout server 10m
+backend omero4064-1
+    mode tcp
+    balance source
+    option tcplog
     server omero4064-192_168_101_18 192.168.101.18:4064 check
     timeout connect 10s
     timeout server 10m


TASK [Create client autoconfiguration file] ************************************
--- before: /srv/www/connection/omero-client.json
+++ after: /Users/spli/.ansible/tmp/ansible-local-27293uyiv4yzj/tmpb1qzow9q/omero-client.json.j2
@@ -1,4 +1,4 @@
 [
-"--Ice.Default.Router=OMERO.Glacier2/router:ssl -p 14060 -h @omero.host@",
+"--Ice.Default.Router=OMERO.Glacier2/router:ssl -p 14060 -h @omero.host@:ssl -p 14061 -h @omero.host@",
 "--Ice.Default.Router.EndpointSelection=Random"
 ]


TASK [ome.nginx_proxy : nginx | proxy upstream servers] ************************
--- before: /etc/nginx/conf.d/proxy-upstream.conf
+++ after: /Users/spli/.ansible/tmp/ansible-local-27293uyiv4yzj/tmpgea8p03l/nginx-confd-proxy-upstream.j2
@@ -4,10 +4,10 @@
   ip_hash;
   server 192.168.101.15;
   server 192.168.101.16;
-  server 192.168.101.17;
 }
 upstream omeroreadonlywebsockets {
   ip_hash;
+  server 192.168.101.17:4065;
   server 192.168.101.18:4065;
 }
 upstream omeroreadwrite {

```