### PR TITLE
Add omero_rois

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -68,6 +68,7 @@ omero_server_python_addons:
 - omero-cli-render==0.5.0
 - omero-metadata==0.5.0
 - omero-upload==0.3.0
+- omero-rois==0.3.0
 
 omero_server_config_set:
   omero.db.poolsize: 25


### PR DESCRIPTION
Adds https://pypi.org/project/omero-rois package, which is handy if one needs to convert segmented images into ROIs.
