### PR TITLE
Include public user/pass in omero-client.json

### DIFF
--- a/ansible/templates/omero-client.json.j2
+++ b/ansible/templates/omero-client.json.j2
@@ -3,5 +3,7 @@
 {%- for backend in omero_omeroreadonly_hosts_external -%}
 :ssl -p {{ idr_haproxy_frontend_omero_offset + loop.index0 | int }} -h @omero.host@
 {%- endfor -%}",
-"--Ice.Default.Router.EndpointSelection=Random"
+"--Ice.Default.Router.EndpointSelection=Random",
+"--omero.user=public",
+"--omero.pass=public"
 ]


### PR DESCRIPTION
Closes https://github.com/IDR/deployment/issues/245

Deployed to `test84`

# Testing
```py
from idr import connection
conn = connection('test84.example.org', verbose=2)
for p in conn.listProjects():
    print(p.name)
```