### PR TITLE
Bump IDR Bio-Formats version to 0.6.4

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -25,7 +25,7 @@ idr_bf_components:
   - formats-api
   - formats-bsd
   - formats-gpl
-idr_bf_release: "0.6.3"
+idr_bf_release: "0.6.4-rc1"
 idr_bf_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven/idr"
 
 ice_install_devel: false

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -25,7 +25,7 @@ idr_bf_components:
   - formats-api
   - formats-bsd
   - formats-gpl
-idr_bf_release: "0.6.4-rc1"
+idr_bf_release: "0.6.4"
 idr_bf_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven/idr"
 
 ice_install_devel: false


### PR DESCRIPTION
Includes https://github.com/IDR/bioformats/pull/21 (`idr0048`) and https://github.com/IDR/bioformats/pull/22 (`idr0078`)