### PR TITLE
Do not become when fetching dumps and logs during decommissioning

### DIFF
--- a/ansible/decommission/archive-db.yml
+++ b/ansible/decommission/archive-db.yml
@@ -40,9 +40,6 @@
     - "{{ postgresql_databases }}"
 
   - name: Fetch database dumps
-    # Using become will read the file into memory
-    # http://docs.ansible.com/ansible/latest/fetch_module.html#notes
-    become: no
     fetch:
       dest: /tmp/
       flat: yes

--- a/ansible/decommission/archive-logs.yml
+++ b/ansible/decommission/archive-logs.yml
@@ -27,7 +27,6 @@
     with_items: "{{ logs }}"
 
   - name: Fetch proxy logs archive
-    become: yes
     fetch:
       dest: /tmp/
       flat: yes
@@ -61,7 +60,6 @@
     with_items: "{{ logs }}"
 
   - name: Fetch management logs archive
-    become: yes
     fetch:
       dest: /tmp/
       flat: yes


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/modules/fetch_module.html#notes.

Tested with the `archive-logs.yml` playbook which was seemingly hanging when fetching the `prometheus` archive.