### PR TITLE
Add pandas to notebook

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -69,6 +69,7 @@ omero_server_python_addons:
 - omero-metadata==0.5.0
 - omero-upload==0.3.0
 - omero-rois==0.3.0
+- pandas==1.1.0
 
 omero_server_config_set:
   omero.db.poolsize: 25


### PR DESCRIPTION
During testing of https://github.com/IDR/idr-utils/pull/11 it turned out that no pandas are installed on idr-next.

This PR is adding the line to the playbook.
The command run manually as 

``/path-to/pip install pandas``

showed the version to be 1.1.0

@manics 