### PR TITLE
Revert "Add redirect for idr0048 to downloads"

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -293,8 +293,6 @@ _nginx_proxy_sites:
     nginx_proxy_additional_directives:
     - "add_header Access-Control-Allow-Origin $allow_origin"
     # Study redirects
-    - "if ($request_uri ~ /search/\\?query=Name:idr0048) {
-       return 302 /about/download.html;}"
     - "if ($request_uri ~ /search/\\?query=Name:idr0068) {
        return 302 /about/download.html;}"
 


### PR DESCRIPTION
Reverts IDR/deployment#218

`idr0048` has now been officially released - see https://idr.openmicroscopy.org/search/?query=Name:48
However a custom redirect had been added to redirect https://idr.openmicroscopy.org/search/?query=Name:idr0048 to the Aspera download page. This is no longer necessary and this link should display the gallery result instead