### PR TITLE
Bump omero-iviewer to version 0.10.1

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -212,7 +212,7 @@ omero_web_config_set:
 
 omero_web_apps_packages:
 - omero-mapr==0.4.0
-- omero-iviewer==0.9.1
+- omero-iviewer==0.10.1
 - omero-gallery==3.3.3
 omero_web_apps_names:
 - omero_mapr

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -13,8 +13,8 @@ omero_server_checkupgrade_comparator: '!='
 
 idr_omero_web_release: 5.7.0
 # omero-web depends on omero-py but may not pin the latest release
-# omero_web_python_addons:
-#   - omero-py==5.7.1
+omero_web_python_addons:
+  - omero-py==5.7.1
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,10 +11,10 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.6.3
+idr_omero_web_release: 5.7.0
 # omero-web depends on omero-py but may not pin the latest release
-omero_web_python_addons:
-  - omero-py==5.7.1
+# omero_web_python_addons:
+#   - omero-py==5.7.1
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89


### PR DESCRIPTION
This is primarily driven by the  timestamp bug fix in iviewer. As per the dependency, it also pulls omero-web 5.7.0

See 
- https://github.com/ome/omero-iviewer/blob/v0.10.1/CHANGELOG.md
- https://github.com/ome/omero-web/blob/v5.7.0/CHANGELOG.md
