### PR TITLE
Temporary monitoring for idr-ftp

### DIFF
--- a/ansible/idr-ftp-monitoring.yml
+++ b/ansible/idr-ftp-monitoring.yml
@@ -1,0 +1,23 @@
+# Temporary monitoring configuration
+# This will move to a central management server
+# https://github.com/IDR/deployment/issues/264
+- hosts: "{{ idr_environment | default('idr') }}-ftp-hosts"
+
+  roles:
+  - role: ome.prometheus_node_new
+
+  - role: ome.prometheus_new
+    prometheus_docker_network: monitoring
+
+    prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
+    prometheus_alertmanager_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
+
+    prometheus_targets:
+    - groupname: nodes
+      groups:
+      - "{{ idr_environment | default('idr') + '-hosts' }}"
+      port: 9100
+      jobname: node-exporter
+      iface: "{{ idr_net_iface | default('eth0') }}"
+
+    prometheus_additional_rules_template: idrftp-alert-rules-yml.j2

--- a/ansible/idr-ftp-monitoring.yml
+++ b/ansible/idr-ftp-monitoring.yml
@@ -4,9 +4,9 @@
 - hosts: "{{ idr_environment | default('idr') }}-ftp-hosts"
 
   roles:
-  - role: ome.prometheus_node_new
+  - role: ome.prometheus_node_0_3_0
 
-  - role: ome.prometheus_new
+  - role: ome.prometheus_0_4_0
     prometheus_docker_network: monitoring
 
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -193,3 +193,15 @@
 
 - src: ome.prometheus_postgres
   version: 0.3.0
+
+# https://github.com/ome/ansible-role-prometheus/pull/7/commits/fdcfaf93604b86fa753a2ae6d69d20d91c1292d1
+- name: ome.prometheus_new
+  src:
+    https://github.com/ome/ansible-role-prometheus/archive/fdcfaf93604b86fa753a2ae6d69d20d91c1292d1.tar.gz
+  version: fdcfaf93604b86fa753a2ae6d69d20d91c1292d1
+
+# https://github.com/ome/ansible-role-prometheus-node/pull/4
+- name: ome.prometheus_node_new
+  src:
+    https://github.com/ome/ansible-role-prometheus-node/archive/07a0ef66d66ca03e4056c1e6e3e2b1a645be04fb.tar.gz
+  version: 07a0ef66d66ca03e4056c1e6e3e2b1a645be04fb

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -194,14 +194,12 @@
 - src: ome.prometheus_postgres
   version: 0.3.0
 
-# https://github.com/ome/ansible-role-prometheus/pull/7/commits/fdcfaf93604b86fa753a2ae6d69d20d91c1292d1
-- name: ome.prometheus_new
+- name: ome.prometheus_0_4_0
   src:
-    https://github.com/ome/ansible-role-prometheus/archive/fdcfaf93604b86fa753a2ae6d69d20d91c1292d1.tar.gz
-  version: fdcfaf93604b86fa753a2ae6d69d20d91c1292d1
+    https://github.com/ome/ansible-role-prometheus/archive/0.4.0.tar.gz
+  version: 0.4.0
 
-# https://github.com/ome/ansible-role-prometheus-node/pull/4
-- name: ome.prometheus_node_new
+- name: ome.prometheus_node_0_3_0
   src:
-    https://github.com/ome/ansible-role-prometheus-node/archive/07a0ef66d66ca03e4056c1e6e3e2b1a645be04fb.tar.gz
-  version: 07a0ef66d66ca03e4056c1e6e3e2b1a645be04fb
+    https://github.com/ome/ansible-role-prometheus-node/archive/0.3.0.tar.gz
+  version: 0.3.0

--- a/ansible/templates/idrftp-alert-rules-yml.j2
+++ b/ansible/templates/idrftp-alert-rules-yml.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+# See https://awesome-prometheus-alerts.grep.to/rules
+# for useful rules but note the labels may be different
+# Remember this is a Jinja2 template processed by Ansible
+
+{% raw %}
+
+groups:
+
+- name: 10% disk space remaining
+  rules:
+
+  - alert: HostOutOfDiskSpace
+    expr: (node_filesystem_avail_bytes{mountpoint="/data"} * 100) / node_filesystem_size_bytes{mountpoint="/data"} < 10
+    # for: 5m
+    for: 10s
+    labels:
+      severity: warn
+    annotations:
+      summary: "Host out of disk space (instance {{ $labels.instance }})"
+      description: "Disk is almost full (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+{% endraw -%}


### PR DESCRIPTION
This installs a full updated prometheus deployment on idr-ftp to give us immediate disk space alerts. Later it will be replaced by a dedicated shared monitoring/management server: https://github.com/IDR/deployment/issues/264

`ssh <testftp-server> -L 19090:localhost:9090`
- Prometheus alerts dashboard: http://localhost:19090/alerts
- `/data` % free http://localhost:19090/graph?g0.range_input=1h&g0.expr=(node_filesystem_avail_bytes%7Bmountpoint%3D%22%2Fdata%22%7D%20*%20100)%20%2F%20node_filesystem_size_bytes%7Bmountpoint%3D%22%2Fdata%22%7D&g0.tab=0

An alert should be sent to Slack `#idr-notify-testftp` (needs to be renamed `#idr-notify-idrftp` for production) if the free disk space on `/data` falls below 10%. The current volume on the test server is 100 GB and I've created an 85GB file in `/data`: 
```
$ sudo dd if=/dev/zero of=fill-space-85G bs=1G count=85
```
```
$ df -h /data
/dev/vdb        100G   86G   15G  86% /data
```

So you can test by creating a 6GB file and waiting a few minutes for a slack alert. Note there are multiple time delays that interact, don't just look at one config file.
```
$ sudo dd if=/dev/zero of=fill-more-space bs=1G count=6`
```

For now I'm using updated prometheus roles under a `_new` suffix so that we can get this deployed ASAP. https://github.com/IDR/deployment/issues/264 covers planned additional work.

requires
- [x] https://github.com/ome/ansible-role-prometheus/pull/7
- [x] https://github.com/ome/ansible-role-prometheus-node/pull/4