### PR TITLE
Decommissioning improvements

### DIFF
--- a/ansible/decommission/archive-db.yml
+++ b/ansible/decommission/archive-db.yml
@@ -46,6 +46,7 @@
       src: /tmp/{{ decommission_archive_prefix }}-database-{{ item.name }}.pg_dump
     with_items:
     - "{{ postgresql_databases }}"
+    when: 'download_dump | default(False)'
 
   - name: Print dump information
     debug:

--- a/ansible/decommission/archive-instance-services.yml
+++ b/ansible/decommission/archive-instance-services.yml
@@ -12,15 +12,15 @@
       state: stopped
       enabled: False
     with_items:
+    - prometheus-node-exporter
+    - prometheus-omero-py
+    - omero-logmonitor
     - omero-server
     - omero-web
-    - omero-logmonitor
     - redis
     - httpd
     - nginx
     - postgresql-9.6
     - postgresql-11
-    - prometheus-node-exporter
-    - prometheus-omero-py
     - docker
     ignore_errors: yes

--- a/ansible/decommission/archive-instance-services.yml
+++ b/ansible/decommission/archive-instance-services.yml
@@ -12,8 +12,6 @@
       state: stopped
       enabled: False
     with_items:
-    - prometheus-node-exporter
-    - prometheus-omero-py
     - omero-logmonitor
     - omero-server
     - omero-web
@@ -22,5 +20,7 @@
     - nginx
     - postgresql-9.6
     - postgresql-11
+    - prometheus-node-exporter
+    - prometheus-omero-py
     - docker
     ignore_errors: yes

--- a/ansible/decommission/archive-logs.yml
+++ b/ansible/decommission/archive-logs.yml
@@ -32,13 +32,13 @@
       flat: yes
       src: /tmp/{{ decommission_archive_prefix }}-{{ item.name }}.tar.gz
     with_items: "{{ logs }}"
+    when: 'download_dump | default(False)'
 
   - name: Print archive information
     debug:
       msg: >
         Archived {{ item.archived | length }} files
         from {{ ansible_hostname }}:{{ item.expanded_paths | join(',') }}
-        to /tmp/{{ item.dest | basename }}
     with_items: "{{_decommission_archive_proxy.results}}"
 
 
@@ -65,11 +65,11 @@
       flat: yes
       src: /tmp/{{ decommission_archive_prefix }}-{{ item.name }}.tar.gz
     with_items: "{{ logs }}"
+    when: 'download_dump | default(False)'
 
   - name: Print archive information
     debug:
       msg: >
         Archived {{ item.archived | length }} files
         from {{ ansible_hostname }}:{{ item.expanded_paths | join(',') }}
-        to /tmp/{{ item.dest | basename }}
     with_items: "{{_decommission_archive_management.results}}"


### PR DESCRIPTION
Small improvements:

- following a RFE from @joshmoore, ebabdd3  should ensure monitoring and slack alerting agents are shut down before stopping the other services
- 28f6ec6 primarily aims at speeding up the decommissioning process. At the moment, the DB dump/log archives are first downloaded locally then copied over to our UoD location. Skipping the local copy step, I ended up simply rsyncing the logs/dumps into their final location on `idr0-slot3` as:

   ```
   rsync -av idr-next:/tmp/prod86-proxy-* . --progress
   rsync -av -e "ssh idr-next ssh" database:/tmp/prod86-database-* . -vv --progress
   rsync -av -e "ssh idr-next ssh" management:/tmp/prod86-management-* . --progress
   ```

If the above sounds like the canonical to go, happy to more simply remove the `fetch` commands.

With the transfer step reduced to a single copy step, I think most of the bottleneck of the decommissioning process comes down to the `pgdump` itself (currently dumping ~5GB takes typically 1h). If the dump format is not critical, the obvious next thing to try would be to switch to parallel export with `-Fd` in https://github.com/IDR/deployment/blob/IDR-0.8.7/ansible/decommission/archive-db.yml#L28