### PR TITLE
Add redirects for idr0078, idr0089, idr0090 and idr0094

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -295,7 +295,14 @@ _nginx_proxy_sites:
     # Study redirects
     - "if ($request_uri ~ /search/\\?query=Name:idr0068) {
        return 302 /about/download.html;}"
-
+    - "if ($request_uri ~ /search/\\?query=Name:idr0078) {
+       return 302 /about/download.html;}"
+    - "if ($request_uri ~ /search/\\?query=Name:idr0089) {
+       return 302 /about/download.html;}"
+    - "if ($request_uri ~ /search/\\?query=Name:idr0090) {
+       return 302 /about/download.html;}"
+    - "if ($request_uri ~ /search/\\?query=Name:idr0094) {
+       return 302 /about/download.html;}"
 
   # This is a duplicate of the main OMERO.web proxy configuration, but with
   # cache-busting:

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -293,15 +293,15 @@ _nginx_proxy_sites:
     nginx_proxy_additional_directives:
     - "add_header Access-Control-Allow-Origin $allow_origin"
     # Study redirects
-    - "if ($request_uri ~ /search/\\?query=Name:idr0068) {
+    - "if ($request_uri ~ /search/\\?query=Name:(.*)68) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:idr0078) {
+    - "if ($request_uri ~ /search/\\?query=Name:(.*)78) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:idr0089) {
+    - "if ($request_uri ~ /search/\\?query=Name:(.*)89) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:idr0090) {
+    - "if ($request_uri ~ /search/\\?query=Name:(.*)90) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:idr0094) {
+    - "if ($request_uri ~ /search/\\?query=Name:(.*)94) {
        return 302 /about/download.html;}"
 
   # This is a duplicate of the main OMERO.web proxy configuration, but with

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -293,15 +293,15 @@ _nginx_proxy_sites:
     nginx_proxy_additional_directives:
     - "add_header Access-Control-Allow-Origin $allow_origin"
     # Study redirects
-    - "if ($request_uri ~ /search/\\?query=Name:(.*)68) {
+    - "if ($request_uri ~ /search/\\?query=Name:(idr00)?68) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:(.*)78) {
+    - "if ($request_uri ~ /search/\\?query=Name:(idr00)?78) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:(.*)89) {
+    - "if ($request_uri ~ /search/\\?query=Name:(idr00)?89) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:(.*)90) {
+    - "if ($request_uri ~ /search/\\?query=Name:(idr00)?90) {
        return 302 /about/download.html;}"
-    - "if ($request_uri ~ /search/\\?query=Name:(.*)94) {
+    - "if ($request_uri ~ /search/\\?query=Name:(idr00)?94) {
        return 302 /about/download.html;}"
 
   # This is a duplicate of the main OMERO.web proxy configuration, but with


### PR DESCRIPTION
These studies are scheduled for publication in upcoming releases of IDR. In the meantime, the searches should redirect to the download page as the raw data is publicly available.

To be deployed on `idr-next` for testing, then on `idr`