### PR TITLE
OMERO.web 5.8.0 OMERO.py 5.8.0

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,14 +11,14 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.7.0
+idr_omero_web_release: 5.8.0
 # omero-web depends on omero-py but may not pin the latest release
 omero_web_python_addons:
-  - omero-py==5.7.1
+  - omero-py==5.8.0
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
-_omero_py_version: ==5.7.1
+_omero_py_version: ==5.8.0
 
 # The IDR OMERO server uses a custom IDR build
 idr_bf_components:


### PR DESCRIPTION
Not deployed anywhere, we can wait for the next test server