### PR TITLE
Expand OpenStack data volume to 1.2 TB

### DIFF
--- a/ansible/openstack-create-pilotidr-omero.yml
+++ b/ansible/openstack-create-pilotidr-omero.yml
@@ -40,7 +40,7 @@
       openstack_volume_source: "{{ idr_volume_database_db_src }}"
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 1000
+      openstack_volume_size: 1200
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdc

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -107,7 +107,7 @@
       openstack_volume_source: "{{ idr_volume_database_db_src }}"
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 1000
+      openstack_volume_size: 1200
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdb


### PR DESCRIPTION
The recent import work is bringing us closer to the 1000G size of the `/data` volume. On `prod88`

```
[sbesson@prod88-omeroreadwrite ~]$ df -h
Filesystem                    Size  Used Avail Use% Mounted on
devtmpfs                       32G     0   32G   0% /dev
tmpfs                          32G     0   32G   0% /dev/shm
tmpfs                          32G  720K   32G   1% /run
tmpfs                          32G     0   32G   0% /sys/fs/cgroup
/dev/vda1                     100G  9.4G   91G  10% /
/dev/vdb                     1000G  884G  117G  89% /data
10.35.106.250:/fg_bioimage    600T  321T  280T  54% /nfs/bioimage
10.35.106.251:/fg_biostudies  302T  249T   53T  83% /nfs/biostudies
tmpfs                         6.3G     0  6.3G   0% /run/user/11615
tmpfs                         6.3G     0  6.3G   0% /run/user/5098
```

This should increase the volume space by 200G and keep us running for a few releases. Parallelly, we can look into saving space by zipping/deleting unnecessary files and/or moving large files to NFS

