### PR TITLE
Drop addition of Access-Control header

### DIFF
--- a/ansible/idr-s3gateway.yml
+++ b/ansible/idr-s3gateway.yml
@@ -55,9 +55,6 @@
             - proxy_http_version 1.1
             - proxy_request_buffering off
             - proxy_buffering off
-            # CORS: basically allow any cross-site since this is public
-            # read-only. Always set a header including on 404 responses
-            - "add_header Access-Control-Allow-Origin * always"
         # all other hostnames: redirect to https://idr.openmicroscopy.org/
         - nginx_proxy_is_default: True
           nginx_proxy_direct_locations:


### PR DESCRIPTION
Having the header added twice broke clients. Removing
for the moment, but a conditional addition would be
safest.

see: https://forum.image.sc/t/mirroring-idr-zarr-datasets/41136/16?u=joshmoore