### PR TITLE
Bump omero-py to 5.8.2 and omero-web to 5.8.1

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -18,7 +18,7 @@ omero_web_python_addons:
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
-_omero_py_version: ==5.8.0
+_omero_py_version: ==5.8.2
 
 # The IDR OMERO server uses a custom IDR build
 idr_bf_components:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,10 +11,10 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.8.0
+idr_omero_web_release: 5.8.1
 # omero-web depends on omero-py but may not pin the latest release
 omero_web_python_addons:
-  - omero-py==5.8.0
+  - omero-py==5.8.2
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89


### PR DESCRIPTION
See https://github.com/ome/omero-py/blob/v5.8.2/CHANGELOG.md and
https://github.com/ome/omero-web/blob/v5.8.1/CHANGELOG.md for the list of changes

Fixes https://github.com/IDR/idr-utils/issues/27

With this change `omero` commands piped to an output file requiring an interactive user input should fail rather than hang.