### PR TITLE
omero-client.json: use wss (websockets)

### DIFF
--- a/ansible/templates/omero-client.json.j2
+++ b/ansible/templates/omero-client.json.j2
@@ -1,9 +1,5 @@
 [
-"--Ice.Default.Router=OMERO.Glacier2/router
-{%- for backend in omero_omeroreadonly_hosts_external -%}
-:ssl -p {{ idr_haproxy_frontend_omero_offset + loop.index0 | int }} -h @omero.host@
-{%- endfor -%}",
-"--Ice.Default.Router.EndpointSelection=Random",
+"--Ice.Default.Router=OMERO.Glacier2/router:wss -p 443 -h @omero.host@ -r /omero-ws",
 "--omero.user=public",
 "--omero.pass=public"
 ]


### PR DESCRIPTION
Once this is deployed
```py
from idr import connection()
c = connection('idr.openmicroscopy.org')
```
should automatically use websockets.

Requires https://github.com/IDR/deployment/pull/287