### PR TITLE
Also mount EBI NFS mounts on FTP server

### DIFF
--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -23,7 +23,7 @@
   - role: ome.nfs_mount
     nfs_version: 3
     nfs_mount_opts: timeo=14,intr,nolock,ro
-    nfs_share_mounts: "{{ ebi_nfs_mounts }}"
+    nfs_share_mounts: "{{ ebi_nfs_mounts | default([]) }}"
 
   tasks:
 

--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -20,6 +20,11 @@
     #anonymous_ftp_emails:
     #anonymous_ftp_public_address:
 
+  - role: ome.nfs_mount
+    nfs_version: 3
+    nfs_mount_opts: timeo=14,intr,nolock,ro
+    nfs_share_mounts: "{{ ebi_nfs_mounts }}"
+
   tasks:
 
   - name: ftp | create alternate upload group

--- a/ansible/openstack-create-ftp.yml
+++ b/ansible/openstack-create-ftp.yml
@@ -66,11 +66,18 @@
     - "{{ idr_environment_idr }}-ftp-hosts"
     - "{{ idr_environment_idr }}-data-hosts"
     - ftp-hosts
+    - "{{ idr_environment_idr }}-{{ idr_vm_storage_group }}"
+    - "{{ idr_vm_storage_group }}"
     idr_vm_networks:
     - net-name: "{{ idr_environment_idr }}"
     idr_vm_security_groups:
     - default
     - "{{ idr_environment_idr }}-ftp-external"
+    idr_vm_networks: >
+      {{ [ {'net-name': idr_environment_idr} ] +
+         ((idr_network_storage | length > 0) |
+           ternary([{'net-name': idr_network_storage}], []))
+      }}
 
 
   ############################################################


### PR DESCRIPTION
An increasing number of IDR submissions are undergoing conversion via `bioformats2raw` esp. to construct pyramidal level. This conversion usually involves:

- access to the original data, minimally in read-only
- some conversion tools/pipeline - Docker-based containers have been predominantly used lately
- writing the converted data to disk i.e. sufficient disk space depending on the data
- copying the local data to EBI NFS - Aspera within EBI is currently the fastest way to achieve this

In order to progress with a submission blocked at the conversion level, this PR proposes to mount EBI NFS as read-only on the FTP server as it meets most of the criteria defined above.
