### PR TITLE
Install dstat on idr-ftp

### DIFF
--- a/ansible/idr-ftp-monitoring.yml
+++ b/ansible/idr-ftp-monitoring.yml
@@ -21,3 +21,10 @@
       iface: "{{ idr_net_iface | default('eth0') }}"
 
     prometheus_additional_rules_template: idrftp-alert-rules-yml.j2
+
+  tasks:
+  - name: idr-ftp monitoring | Install dstat
+    become: yes
+    yum:
+      name: dstat
+      state: present


### PR DESCRIPTION
This is useful for monitoring performance

We could install this on all VMs, for now it's just idr-ftp since we're investigating S3 performance issues.