### PR TITLE
Add monitoring to the pilot deployments

### DIFF
--- a/ansible/grafana-dashboards/idr-postgresql.json
+++ b/ansible/grafana-dashboards/idr-postgresql.json
@@ -1,266 +1,583 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.4.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "hideControls": false,
-  "id": null,
+  "id": 4,
+  "iteration": 1606920921189,
   "links": [],
-  "rows": [
+  "panels": [
     {
-      "collapse": false,
-      "height": "250px",
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Number of rows/second queried across all tables",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "hostname": {
+          "selected": false,
+          "text": "pilot-idr0071-omeroreadwrite",
+          "value": "pilot-idr0071-omeroreadwrite"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Number of rows/second queried across all tables",
-          "fill": 1,
-          "id": 1,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "deleted",
-              "metric": "",
-              "refId": "A",
-              "step": 20
-            },
-            {
-              "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "fetched",
-              "refId": "B",
-              "step": 20
-            },
-            {
-              "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "inserted",
-              "metric": "",
-              "refId": "C",
-              "step": 20
-            },
-            {
-              "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "returned",
-              "refId": "D",
-              "step": 20
-            },
-            {
-              "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\"}[5m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "updated",
-              "refId": "E",
-              "step": 20
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Number of rows",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "ops",
-              "label": "",
-              "logBase": 10,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
+          "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "deleted",
+          "metric": "",
+          "refId": "A",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "fetched",
+          "refId": "B",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "inserted",
+          "metric": "",
+          "refId": "C",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "returned",
+          "refId": "D",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "updated",
+          "refId": "E",
+          "step": 20
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname Number of rows",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": "",
+          "logBase": 10,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-      "collapse": false,
-      "height": 250,
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "hostname",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "hostname": {
+          "selected": false,
+          "text": "pilot-idr0071-omeroreadwrite",
+          "value": "pilot-idr0071-omeroreadwrite"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
-          "id": 2,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "pg_locks_count{datname=\"idr\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{mode}}",
-              "metric": "pg_locks_count",
-              "refId": "A",
-              "step": 20
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Locks",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
+          "expr": "pg_locks_count{datname=\"idr\",instance=\"$hostname\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{mode}}",
+          "metric": "pg_locks_count",
+          "refId": "A",
+          "step": 20
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname Locks",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Number of rows/second queried across all tables",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "repeatIteration": 1606920921189,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "hostname": {
+          "selected": false,
+          "text": "pilot-idr0099-omeroreadwrite",
+          "value": "pilot-idr0099-omeroreadwrite"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "deleted",
+          "metric": "",
+          "refId": "A",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "fetched",
+          "refId": "B",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "inserted",
+          "metric": "",
+          "refId": "C",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "returned",
+          "refId": "D",
+          "step": 20
+        },
+        {
+          "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\",instance=\"$hostname\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "updated",
+          "refId": "E",
+          "step": 20
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname Number of rows",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": "",
+          "logBase": 10,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "repeatIteration": 1606920921189,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "hostname": {
+          "selected": false,
+          "text": "pilot-idr0099-omeroreadwrite",
+          "value": "pilot-idr0099-omeroreadwrite"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "pg_locks_count{datname=\"idr\",instance=\"$hostname\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{mode}}",
+          "metric": "pg_locks_count",
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "$hostname Locks",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "schemaVersion": 14,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(postgres_exporter_build_info,instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": true,
+        "name": "hostname",
+        "options": [],
+        "query": "label_values(postgres_exporter_build_info,instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-3h",
@@ -293,5 +610,6 @@
   },
   "timezone": "",
   "title": "IDR PostgreSQL",
-  "version": 6
+  "uid": "8-TpsT0Mz",
+  "version": 7
 }

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -132,6 +132,11 @@
     kibana_docker_image: "docker.elastic.co/kibana/kibana-oss:6.1.1"
 
 
+# Load hostvars for management server
+- hosts: >-
+    {{ idr_environment | default('idr') }}-management-hosts
+    {{ idr_parent_environment | default('idr') }}-management-hosts
+
 
 - hosts: >
     {{ idr_environment | default('idr') }}-proxy-hosts
@@ -188,5 +193,6 @@
   - role: ome.fluentd
 
   vars:
-    fluentd_server_address: "{{ hostvars[groups[idr_environment | default('idr') + '-management-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
+    _monitoring_idr_environment: "{{ idr_parent_environment | default(idr_environment | default('idr')) + '-management-hosts' }}"
+    fluentd_server_address: "{{ hostvars[groups[_monitoring_idr_environment][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}"
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -61,6 +61,9 @@
   - role: ome.cadvisor
 
 
+# If this is a pilot monitoring server we haven't yet loaded hostvars
+- hosts: "{{ idr_environment | default('idr') }}-pilotidr-hosts"
+
 - hosts: "{{ idr_environment | default('idr') }}-management-hosts"
 
   roles:
@@ -90,7 +93,7 @@
 
     - groupname: blitz
       groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      - "{{ idr_environment | default('idr') + monitoring_group_prefix + 'omero-hosts' }}"
       port: 9180
       jobname: jmx-blitz
       iface: "{{ idr_net_iface | default('eth0') }}"
@@ -122,14 +125,14 @@
     # and one for detailed statement performance metrics
     - groupname: postgres
       groups:
-      - "{{ idr_environment | default('idr') + '-database-hosts' }}"
+      - "{{ idr_environment | default('idr') + monitoring_group_prefix + 'database-hosts' }}"
       port: 9187
       jobname: postgres-exporter
       iface: "{{ idr_net_iface | default('eth0') }}"
 
     - groupname: omero-web
       groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      - "{{ idr_environment | default('idr') + monitoring_group_prefix + 'omero-hosts' }}"
       port: 80
       jobname: django
       metrics_path: /django_prometheus/metrics
@@ -137,15 +140,18 @@
 
     - groupname: omero-sessions
       groups:
-      - "{{ idr_environment | default('idr') + '-omero-hosts' }}"
+      - "{{ idr_environment | default('idr') + monitoring_group_prefix + 'omero-hosts' }}"
       port: 9449
       jobname: omero-sessions
       iface: "{{ idr_net_iface | default('eth0') }}"
 
     prometheus_http_2xx_internal_targets: >
       {{
-        (groups[(idr_environment | default('idr')) + '-omero-hosts'] +
+        (groups[(idr_environment | default('idr')) + monitoring_group_prefix + 'omero-hosts'] +
+          (
              groups[(idr_environment | default('idr')) + '-proxy-hosts']
+             | default([])
+          )
         ) |
         map('extract', hostvars, [
             'ansible_' + (hosts_populate_iface | default('eth0')),
@@ -161,3 +167,12 @@
 
     prometheus_rsync_banner_targets:
     - idr.openmicroscopy.org:873
+
+  vars:
+    # If this is the pilot management server we need to scrape
+    # hosts in the individual pilot deployments
+    monitoring_group_prefix: >-
+      {{
+        (idr_enable_pilotidr | default(False)) |
+          ternary('-pilot', '-')
+      }}

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -86,7 +86,7 @@
     prometheus_targets:
     - groupname: nodes
       groups:
-      - "{{ idr_environment | default('idr') + '-hosts' }}"
+      - "{{ idr_environment | default('idr') + monitoring_all_prefix + '-hosts' }}"
       port: 9100
       jobname: node-exporter
       iface: "{{ idr_net_iface | default('eth0') }}"
@@ -169,6 +169,16 @@
     - idr.openmicroscopy.org:873
 
   vars:
+    # If this is the pilot management server we need to scrape:
+    #   hosts in the individual pilot deployments <idrenv>-pilot-hosts
+    #   hosts in parent environment <idrenv>-hosts
+    # In this case there is a special group <idrenv>-pilotidr-hosts
+    # instead of the usual <idrenv>-hosts
+    monitoring_all_prefix: >-
+      {{
+        (idr_enable_pilotidr | default(False)) |
+          ternary('-pilotidr', '')
+      }}
     # If this is the pilot management server we need to scrape
     # hosts in the individual pilot deployments
     monitoring_group_prefix: >-

--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -22,10 +22,14 @@
       idr_vm_omeroreadwrite: True
       idr_vm_extra_groups:
       - "{{ idr_environment_idr }}-{{ idr_vm_storage_group }}"
+      - "{{ idr_vm_storage_group }}"
       # This extra group will let us setup /etc/hosts on the proxy
       # without adding it to the parent environment
       - "{{ idr_parent_environment }}-pilotidr-hosts"
-      - "{{ idr_vm_storage_group }}"
+      # These extra groups allow monitoring in the parent environment to find
+      # these hosts in the individual pilot environments
+      - "{{ idr_parent_environment }}-pilotomero-hosts"
+      - "{{ idr_parent_environment }}-pilotdatabase-hosts"
       idr_vm_networks: >
         {{ [ {'net-name': idr_parent_environment} ] +
           ((idr_network_storage | length > 0) |

--- a/ansible/openstack-create-pilotidr.yml
+++ b/ansible/openstack-create-pilotidr.yml
@@ -53,3 +53,30 @@
         - idr-bastion-external
         - idr-omero-external
         - idr-web-external
+
+
+    ############################################################
+    # Management Instances
+
+    # Dedicated management server
+    - role: IDR.openstack-idr-instance
+      idr_environment: "{{ idr_environment_idr }}"
+      idr_vm_name: "{{ idr_environment_idr }}-management"
+      idr_vm_image: "{{ vm_image }}"
+      idr_vm_flavour: "{{ vm_flavour_medium }}"
+      idr_vm_management: True
+      idr_vm_extra_groups:
+        - "{{ idr_environment_idr }}-data-hosts"
+        - "{{ idr_environment_idr }}-pilotidr-hosts"
+      idr_vm_networks:
+        - net-name: "{{ idr_environment_idr }}"
+
+
+    ############################################################
+    # Management Volume (do not copy when upgrading)
+
+    - role: ome.openstack_volume_storage
+      openstack_volume_size: 100
+      openstack_volume_vmname: "{{ idr_environment_idr }}-management"
+      openstack_volume_name: data
+      openstack_volume_device: /dev/vdb

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -151,7 +151,7 @@
 
 - name: IDR.openstack-idr-instance
   src: https://github.com/IDR/ansible-role-openstack-idr-instance.git
-  version: 2.0.0
+  version: 3.0.0
 
 - name: IDR.openstack-idr-instance-network
   src: https://github.com/IDR/ansible-role-openstack-idr-instance-network.git

--- a/inventories/openstack-idr.py
+++ b/inventories/openstack-idr.py
@@ -103,6 +103,11 @@ def get_groups_from_server(server_vars, namegroup=True):
     for extra_group in metadata.get('groups', '').split(','):
         if extra_group:
             groups.append(extra_group.strip())
+    # Metadata properties are limited to 255 characters, so add in groups from
+    # a second property
+    for extra_group in metadata.get('groups2', '').split(','):
+        if extra_group:
+            groups.append(extra_group.strip())
 
     groups.append('instance-%s' % server_vars['id'])
     if namegroup:


### PR DESCRIPTION
- One monitoring server for all pilot deployments
- Need to add additional openstack group metadata to each pilot IDR, can be done by running the `provision` step on each idrNNNN pilot (metadata will be updated with no downtime)
- Requires https://github.com/IDR/ansible-role-openstack-idr-instance/pull/5 due to the extra metadata going over the limit for a single property