### PR TITLE
OMERO.py 5.9.0rc1: disable unused OMERO components

### DIFF
--- a/ansible/grafana-dashboards/idr-postgresql.json
+++ b/ansible/grafana-dashboards/idr-postgresql.json
@@ -1,4 +1,34 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.2.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -15,8 +45,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1606920921189,
+  "id": null,
+  "iteration": 1607982032204,
   "links": [],
   "panels": [
     {
@@ -24,7 +54,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Number of rows/second queried across all tables",
       "fieldConfig": {
         "defaults": {
@@ -67,13 +97,6 @@
       "renderer": "flot",
       "repeat": "hostname",
       "repeatDirection": "v",
-      "scopedVars": {
-        "hostname": {
-          "selected": false,
-          "text": "pilot-idr0071-omeroreadwrite",
-          "value": "pilot-idr0071-omeroreadwrite"
-        }
-      },
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
@@ -173,7 +196,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -215,275 +238,6 @@
       "renderer": "flot",
       "repeat": "hostname",
       "repeatDirection": "v",
-      "scopedVars": {
-        "hostname": {
-          "selected": false,
-          "text": "pilot-idr0071-omeroreadwrite",
-          "value": "pilot-idr0071-omeroreadwrite"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pg_locks_count{datname=\"idr\",instance=\"$hostname\"}",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{mode}}",
-          "metric": "pg_locks_count",
-          "refId": "A",
-          "step": 20
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$hostname Locks",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "Number of rows/second queried across all tables",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 7
-      },
-      "hiddenSeries": false,
-      "id": 3,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.2.0",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "v",
-      "repeatIteration": 1606920921189,
-      "repeatPanelId": 1,
-      "scopedVars": {
-        "hostname": {
-          "selected": false,
-          "text": "pilot-idr0099-omeroreadwrite",
-          "value": "pilot-idr0099-omeroreadwrite"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "irate(pg_stat_database_tup_deleted{datname=\"idr\",instance=\"$hostname\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "deleted",
-          "metric": "",
-          "refId": "A",
-          "step": 20
-        },
-        {
-          "expr": "irate(pg_stat_database_tup_fetched{datname=\"idr\",instance=\"$hostname\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "fetched",
-          "refId": "B",
-          "step": 20
-        },
-        {
-          "expr": "irate(pg_stat_database_tup_inserted{datname=\"idr\",instance=\"$hostname\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "inserted",
-          "metric": "",
-          "refId": "C",
-          "step": 20
-        },
-        {
-          "expr": "irate(pg_stat_database_tup_returned{datname=\"idr\",instance=\"$hostname\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "returned",
-          "refId": "D",
-          "step": 20
-        },
-        {
-          "expr": "irate(pg_stat_database_tup_updated{datname=\"idr\",instance=\"$hostname\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "updated",
-          "refId": "E",
-          "step": 20
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$hostname Number of rows",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ops",
-          "label": "",
-          "logBase": 10,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 7
-      },
-      "hiddenSeries": false,
-      "id": 4,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.2.0",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeatDirection": "v",
-      "repeatIteration": 1606920921189,
-      "repeatPanelId": 2,
-      "scopedVars": {
-        "hostname": {
-          "selected": false,
-          "text": "pilot-idr0099-omeroreadwrite",
-          "value": "pilot-idr0099-omeroreadwrite"
-        }
-      },
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
@@ -549,16 +303,8 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": "prometheus",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(postgres_exporter_build_info,instance)",
         "hide": 0,
         "includeAll": true,

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -18,7 +18,7 @@ omero_web_python_addons:
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
-_omero_py_version: ==5.8.2
+_omero_py_version: ==5.9.0rc1
 
 # The IDR OMERO server uses a custom IDR build
 idr_bf_components:
@@ -89,6 +89,8 @@ omero_server_config_set:
   omero.client.ui.tree.orphans.enabled: False
   # Websockets (no wss for now to avoid dealing with certificates)
   omero.client.icetransports: ssl,tcp,ws
+  # Disable all components except Blitz and Tables
+  omero.server.nodedescriptors: "master:Blitz-0,Tables-0"
 
 
 ######################################################################

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -100,7 +100,7 @@
     # IDR Volumes
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 500
+      openstack_volume_size: 800
       openstack_volume_vmname: "{{ idr_environment_idr }}-database"
       openstack_volume_name: db
       openstack_volume_device: /dev/vdb


### PR DESCRIPTION
Disable all components except Blitz and Tables

Fixes the postgres grafana dashboard (was exported with the wrong options in https://github.com/IDR/deployment/pull/299)