### PR TITLE
Update playbooks with Ansible 2.8/Molecule 2.22

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,7 +30,7 @@ jobs:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: sbesson/action-ome-ansible-molecule@ome-ansible-molecule_0.5.0
+      - uses: ome/action-ome-ansible-molecule@main
         with:
           scenario: ${{ matrix.scenario }}
           subdir: ansible

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,19 +30,7 @@ jobs:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      # We're using an old version of molecule with an old testinfra version
-      # We need this bugfix
-      # https://github.com/pytest-dev/pytest-testinfra/commit/dd1c40281d5d8d048f51a6e5ecc28471899b1056
-      # So we can't rely on the ome/action-ome-ansible-molecule defaults
-      - uses: actions/setup-python@v2
+      - uses: sbesson/action-ome-ansible-molecule@ome-ansible-molecule_0.5.0
         with:
-          python-version: 3.7
-      - name: Install ome-ansible-molecule
-        run: python -mpip install 'ome-ansible-molecule==0.4.*'
-      - name: Upgrade testinfra
-        run: python -mpip install testinfra==2.1.0
-      - uses: ome/action-ome-ansible-molecule@main
-        with:
-          manage-virtualenv: "false"
           scenario: ${{ matrix.scenario }}
           subdir: ansible

--- a/ansible/idr-haproxy.yml
+++ b/ansible/idr-haproxy.yml
@@ -53,11 +53,12 @@
     become: yes
     file:
       path: /srv/www/connection
-      recurse: yes
       state: directory
+      mode: 0755
 
   - name: Create client autoconfiguration file
     become: yes
     template:
       src: templates/omero-client.json.j2
       dest: /srv/www/connection/omero-client.json
+      mode: 0644

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -13,6 +13,7 @@
     file:
       path: /data/idr-metadata
       state: directory
+      mode: 0755
 
   roles:
 
@@ -41,6 +42,7 @@
         config set -- Ice.Default.Host 127.0.0.1
       dest: /opt/omero/server/config/omero-localhostonly-config.omero
       force: yes
+      mode: 0644
     notify:
     - restart omero-server
 
@@ -51,7 +53,10 @@
   pre_tasks:
   - name: Get fileserver host
     set_fact:
-      omero_fileserver_host_ansible: "{{ hostvars[groups[idr_environment | default('idr') + '-omeroreadwrite-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']}}"
+      omero_fileserver_host_ansible: >-
+        {{ hostvars[groups[idr_environment | default('idr') +
+        '-omeroreadwrite-hosts'][0]][
+        'ansible_' +(idr_net_iface | default('eth0'))]['ipv4']['address'] }}
 
   roles:
   # Use the same paths as on the omeorreadwrite server to reduce confusion
@@ -78,6 +83,7 @@
       path: /opt/omero/server/config/
       recurse: yes
       state: directory
+      mode: 0755
 
   - name: OMERO.server read-only configuration
     become: yes
@@ -87,6 +93,7 @@
         config set -- omero.cluster.read_only true
       dest: /opt/omero/server/config/omero-readonly-config.omero
       force: yes
+      mode: 0644
     notify:
     - restart omero-server if installed
 
@@ -99,6 +106,7 @@
       path: "{{ item }}"
       owner: "{{ omero_server_system_uid }}"
       state: directory
+      mode: 0755
     with_items:
     - /data/OMERO
 
@@ -176,7 +184,10 @@
   tasks:
   - name: Get database host
     set_fact:
-      omero_db_host_ansible: "{{ hostvars[groups[idr_environment | default('idr') + '-database-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']}}"
+      omero_db_host_ansible: >-
+        {{ hostvars[groups[idr_environment | default('idr') +
+        '-database-hosts'][0]][
+        'ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}
 
 
 - hosts: >

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -26,7 +26,10 @@
   tasks:
   - name: Get database host
     set_fact:
-      omero_db_host_ansible: "{{ hostvars[groups[idr_environment | default('idr') + '-database-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']}}"
+      omero_db_host_ansible: >-
+        {{ hostvars[groups[idr_environment | default('idr') +
+        '-database-hosts'][0]][
+        'ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address'] }}
 
 
 # Currently there's a bug in OMERO read-only which means the database

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -13,3 +13,4 @@
       content: "{{ idr_deployment_web_version_value }}"
       dest: "{{ idr_deployment_web_version_file }}"
       force: yes
+      mode: 0644

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -62,7 +62,7 @@
             idr_environment | default('idr') + '-omeroreadwrite-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
-    when: "{{ groups[idr_environment | default('idr') + '-omero-hosts'] is defined }}"
+    when: groups[idr_environment | default('idr') + '-omero-hosts'] is defined
 
   - name: Get management server IP
     set_fact:
@@ -72,7 +72,7 @@
             idr_environment | default('idr') + '-management-hosts'][0]]
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
-    when: "{{ groups[idr_environment | default('idr') + '-management-hosts'] is defined }}"
+    when: groups[idr_environment | default('idr') + '-management-hosts'] is defined
 
   - name: Configure rsync port in selinux
     become: yes

--- a/ansible/molecule/ftp/tests/test_default.py
+++ b/ansible/molecule/ftp/tests/test_default.py
@@ -24,5 +24,5 @@ def test_upload(host):
     # If this test fails it's probably due to a failure in upload_test.sh.
     # An FTP error in that script doesn't exit with an error code
     assert f.exists
-    assert f.content_string.endswith('# IDR FTP molecule test script')
+    assert f.content_string.rstrip().endswith('# IDR FTP molecule test script')
     assert out == ''


### PR DESCRIPTION
--depends-on https://github.com/ome/action-ome-ansible-molecule/pull/1

Not in scope for `prod92` but to be tested when spinning up `prod93`