### PR TITLE
Remove remaining documentation references to the VAE deployment

### DIFF
--- a/ansible/openstack-create-infrastructure.yml
+++ b/ansible/openstack-create-infrastructure.yml
@@ -1,6 +1,6 @@
 # Parent provisioning playbook
 
-# This manages the traditional all-in-one IDR + VAE
+# This manages the production IDR servers
 - include: openstack-create-publicidr.yml
   when: 'idr_enable_publicidr | default(True)'
 

--- a/ansible/vars/openstack-vars.yml
+++ b/ansible/vars/openstack-vars.yml
@@ -11,7 +11,6 @@ vm_flavour_large: m1.xlarge
 vm_flavour_medium: m1.medium
 
 # Copy these volumes for the production IDR
-# The analysis instances will be copied from the current production
 # The default is to initialise new volumes
 idr_volume_database_db_src: "{{ omit }}"
 idr_volume_omero_data_src: "{{ omit }}"

--- a/docs/operating-procedures.md
+++ b/docs/operating-procedures.md
@@ -94,11 +94,6 @@ possible to create a CSV output of the results:
 
     $ screen -dmS cache parallel --eta --sshloginfile nodes -a ids.txt --results /tmp/cache/ --sqlandworker csv:////%2Ftmp%2Fcache.csv -j10 '/opt/omero/server/OMERO.server/bin/omero render -s localhost -u public -w public test --force'
 
-## Analysis IDR
-
-The VAE (JupyterHub) is managed separately. See https://github.com/IDR/k8s-analysis-deploy.
-
-
 ## Backups, restores and upgrades
 
 The IDR has a well-defined separation between applications and data.

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -9,11 +9,6 @@ The production (public-facing) IDR (3 servers):
 - OMERO.servers
 - Nginx gateway
 
-The virtual analysis environment (VAE) IDR (3 servers):
-- Kubernetes master
-- Kubernetes workers
-
-
 ## Ansible prerequisites
 
 Almost all of the provisioning and deployment in the IDR is done using Ansible 2.1.
@@ -32,8 +27,6 @@ The [`ansible.cfg`](../ansible/ansible.cfg) configuration file will install the 
 
 The IDR is currently hosted on OpenStack, see below for an example Ansible playbook for provisioning compute, storage and networking.
 The Ansible openstack modules require the `shade` python module.
-
-This playbook will create two networks `idr` and `idr-a` for the production and analysis servers, and multiple instances and storage volumes.
 
 
 ### Production IDR


### PR DESCRIPTION
Following #311 this removes mentions of the VAE deployment in a few remaining places (code + documentation) /cc @jburel 