### PR TITLE
Bump Ansible roles to their latest released version

### DIFF
--- a/ansible/idr-downloads.yml
+++ b/ansible/idr-downloads.yml
@@ -18,7 +18,7 @@
       comment: /OMERO directory from the IDR
     - name: sql
       path: /srv/omero-sql
-      comment: PostgreSQL 9.4 database dump of the IDR
+      comment: PostgreSQL 11 database dump of the IDR
 
   tasks:
 

--- a/ansible/idr-downloads.yml
+++ b/ansible/idr-downloads.yml
@@ -18,7 +18,7 @@
       comment: /OMERO directory from the IDR
     - name: sql
       path: /srv/omero-sql
-      comment: PostgreSQL 11 database dump of the IDR
+      comment: "PostgreSQL {{ postgresql_version }} database dump of the IDR"
 
   tasks:
 

--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -38,7 +38,7 @@
       when: idr_enable_pilotidr_omero | default(False)
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 500
+      openstack_volume_size: 800
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: db
       openstack_volume_device: /dev/vdb

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -10,34 +10,34 @@
   version: 1.0.1
 
 - src: ome.anonymous_ftp
-  version: 0.1.2
+  version: 0.1.3
 
 - src: ome.basedeps
   version: 1.1.0
 
 - src: ome.cadvisor
-  version: 0.3.1
+  version: 0.3.3
 
 - src: ome.cli_utils
   version: 1.1.0
 
 - src: ome.deploy_archive
-  version: 0.1.3
+  version: 0.1.4
 
 - src: ome.docker
-  version: 3.0.2
+  version: 3.1.1
 
 - src: ome.docker_tools
   version: 1.0.1
 
 - src: ome.haproxy
-  version: 3.2.2
+  version: 3.2.3
 
 - src: ome.hosts_populate
-  version: 0.2.1
+  version: 0.2.3
 
 - src: ome.ice
-  version: 4.0.0
+  version: 4.2.0
 
 - src: ome.iptables_raw
   version: 0.3.1
@@ -46,97 +46,100 @@
   version: 2.1.0
 
 - src: ome.local_accounts
-  version: 1.0.2
+  version: 1.0.3
 
 - src: ome.logrotate
-  version: 1.0.1
+  version: 1.0.2
 
 - src: ome.lvm_partition
   version: 1.1.1
 
 - src: ome.minio_s3_gateway
-  version: 0.1.0
+  version: 0.1.1
 
 - src: ome.munin
-  version: 1.1.3-openmicroscopy2
+  version: 1.1.3-openmicroscopy3
 
 - src: ome.munin_node
   version: 1.2.1-openmicroscopy2
 
 - src: ome.network_cloud_interfaces
-  version: 1.2.2
+  version: 1.2.3
 
 - src: ome.network
-  version: 1.1.3
+  version: 1.1.4
 
 - src: ome.nfs_mount
-  version: 1.2.1
+  version: 1.3.0
 
 - src: ome.nfs_share
-  version: 1.0.3
+  version: 1.0.4
 
 - src: ome.nginx
-  version: 2.0.1
+  version: 2.1.1
 
 - src: ome.nginx_proxy
-  version: 1.13.0
+  version: 1.15.1
 
 - src: ome.omego
   version: 0.2.0
 
 - src: ome.omero_common
-  version: 0.3.2
+  version: 0.3.4
 
 - src: ome.omero_logmonitor
-  version: 2.1.1
+  version: 3.0.1
 
 - src: ome.omero_python_deps
   version: 2.0.1
 
 - src: ome.omero_server
-  version: 3.2.0
+  version: 3.3.1
 
 - src: ome.omero_user
   version: 0.3.0
 
 - src: ome.omero_web
-  version: 3.0.1
+  version: 3.1.1
 
 - src: ome.openstack_volume_storage
   version: 1.1.1
 
 - src: ome.postgresql
-  version: 5.0.0
+  version: 5.0.2
 
 - src: ome.postgresql_client
-  version: 0.1.0
+  version: 0.1.2
+
+- src: ome.python3_virtualenv
+  version: 0.1.1
 
 - src: ome.python_pydata
   version: 1.1.1
 
 - src: ome.reboot_server
-  version: 0.1.2
+  version: 0.1.3
 
 - src: ome.redis
   version: 1.1.1
 
 - src: ome.rsync_server
-  version: 1.0.1
+  version: 1.0.2
 
 - src: ome.selinux_utils
-  version: 2.0.1
+  version: 2.0.2
 
 - src: ome.ssl_certificate
-  version: 0.3.2
+  version: 0.3.3
 
 - src: ome.storage_volume_initialise
-  version: 1.0.1
+  version: 1.0.2
 
 - src: ome.sudoers
-  version: 1.0.1
+  version: 1.0.3
 
 - src: ome.upgrade_distpackages
-  version: 1.1.1
+  version: 1.1.3
 
 - src: ome.versioncontrol_utils
   version: 1.0.2
@@ -170,22 +173,22 @@
 # External development roles
 
 - src: ome.fluentd
-  version: 0.2.2
+  version: 0.2.3
 
 - src: ome.omero_prometheus_exporter
-  version: 0.3.0
+  version: 0.3.1
 
 - src: ome.omero_web_django_prometheus
-  version: 0.4.0
+  version: 0.4.1
 
 - src: ome.prometheus
-  version: 0.4.0
+  version: 0.5.1
 
 - name: ome.prometheus_jmx
-  version: 0.2.2
+  version: 0.3.1
 
 - src: ome.prometheus_node
-  version: 0.3.0
+  version: 0.3.1
 
 - src: ome.prometheus_postgres
-  version: 0.4.0
+  version: 0.4.2


### PR DESCRIPTION
This PR performs a routine update of the Ansible roles to consume the latest releases. Most of the the increments are patch releases following the Ansible 2.8 upgrade. Below are listed the minor/major bumps with a list of the features 

- ome.docker 3.0.2 -> 3.1.1: allow to override yum repo
- ome.ice 4.0.1 -> 4.2.0: do not use runtime package, use set become
- ome.nfs_mount 1.2.1 -> 1.3.0: support mount state and multiple nfs versions
- ome.nginx 2.0.1 -> 2.1.1: allow to manage nginx without systemd
- ome.nginx_proxy 1.13.0 -> 1.15.1: additional directives, allow to not restart nginx via systemd
- ome.omero_logmonitor 2.1.1 -> 3.0.1: upgrade to Python 3
- ome.omero_server 3.2.0 -> 3.3.1: use ome.python3_virtualenv
- ome.omero_web 3.0.1 -> 3.1.1: use ome.python3_virtualenv
- ome.prometheus 0.4.0 -> 0.5.1: support deployment outside cloud
- ome.prometheus_jmx 0.2.2 -> 0.3.1: prometheus_jmx upgrade

Proposing for the deployment of `prod94`