### PR TITLE
Add mapr configuration for Protein Supplementary annotations

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -451,6 +451,13 @@ omero_web_apps_config_set:
       ns:
         - "openmicroscopy.org/mapr/protein"
       label: "Protein"
+  - menu: "proteinsupplementary"
+    config:
+      default: []
+      all: []
+      ns:
+        - "openmicroscopy.org/mapr/protein/supplementary"
+      label: "Protein supplementary"
   - menu: "others"
     config:
       default:


### PR DESCRIPTION
In the context of the upcoming `idr0072`, this defines a new Protein Supplementary map annotation.