### PR TITLE
OMERO.server: upgrade and self-signed certificates

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,19 +6,17 @@
 ######################################################################
 # Shared variables
 
-# Force a downgrade from 5.6.1
-# https://github.com/ome/omero-server/issues/93
-idr_omero_server_release: 5.6.0
+idr_omero_server_release: 5.6.3
 omero_server_checkupgrade_comparator: '!='
 
 idr_omero_web_release: 5.9.1
 # omero-web depends on omero-py but may not pin the latest release
 omero_web_python_addons:
-  - omero-py==5.9.0
+  - omero-py==5.9.1
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
-_omero_py_version: ==5.9.0
+_omero_py_version: ==5.9.1
 
 # The IDR OMERO server uses a custom IDR build
 idr_bf_components:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -59,7 +59,7 @@ omero_server_system_uid: 546
 omero_server_system_managedrepo_group: idr-data
 omero_server_datadir: /data/OMERO
 omero_server_datadir_bioformatscache: /data/BioFormatsCache
-omero_server_selfsigned_certificates: True
+
 omero_server_systemd_limit_nofile: 16384
 
 omero_server_python_addons:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -59,7 +59,7 @@ omero_server_system_uid: 546
 omero_server_system_managedrepo_group: idr-data
 omero_server_datadir: /data/OMERO
 omero_server_datadir_bioformatscache: /data/BioFormatsCache
-
+omero_server_selfsigned_certificates: True
 omero_server_systemd_limit_nofile: 16384
 
 omero_server_python_addons:

--- a/ansible/group_vars/omeroreadwrite-hosts.yml
+++ b/ansible/group_vars/omeroreadwrite-hosts.yml
@@ -5,6 +5,7 @@
 
 omero_server_dbuser: omero
 omero_server_dbpassword: "{{ idr_secret_postgresql_password | default('omero') }}"
+omero_server_selfsigned_certificates: True
 
 idr_omero_web_timeout: 900
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -88,7 +88,7 @@
   version: 3.0.1
 
 - src: ome.omero_server
-  version: 4.0.0
+  version: 4.0.1
 
 - src: ome.omero_user
   version: 0.3.0


### PR DESCRIPTION
Fixes https://github.com/IDR/deployment/issues/327

- [x] deploy upgrade on `prod97`
- [x] remove the previous cache directory
- [ ] regenerate the memo files for a few studies with many files: idr0044 (original issue), idr0065, idr0094 
- [ ] collect access metrics
- [ ] upgrade the DB with the script of https://github.com/ome/openmicroscopy/pull/6275/files and retest
- [ ] regenerate memo files for all images in IDR