### PR TITLE
Support OpenJDK 11.0.11

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -20,13 +20,31 @@ omero_web_python_addons:
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
 _omero_py_version: ==5.9.0
 
+artifactory_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven"
+
+# Override the lib/client JARs on the omeroreadwrite server
+# Works around the OMERO.server 5.6.3 upgrade issue - to be reverted when
+# the server is upgraded
+# See https://github.com/IDR/deployment/issues/327
+omero_client_jars:
+  - name: omero-romio
+    group: org/openmicroscopy
+    version: "5.6.2"
+  - name: omero-blitz
+    group: org/openmicroscopy
+    version: "5.5.8"
+
 # The IDR OMERO server uses a custom IDR build
-idr_bf_components:
-  - formats-api
-  - formats-bsd
-  - formats-gpl
-idr_bf_release: "0.6.6"
-idr_bf_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven/idr"
+idr_bf_jars:
+  - name: formats-api
+    group: idr
+    version: "0.6.6"
+  - name: formats-bsd
+    group: idr
+    version: "0.6.6"
+  - name: formats-gpl
+    group: idr
+    version: "0.6.6"
 
 ice_install_devel: false
 ice_install_python: false

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -61,7 +61,7 @@ omero_server_system_uid: 546
 omero_server_system_managedrepo_group: idr-data
 omero_server_datadir: /data/OMERO
 omero_server_datadir_bioformatscache: /data/BioFormatsCache
-omero_server_selfsigned_certificates: True
+
 omero_server_systemd_limit_nofile: 16384
 
 omero_server_python_addons:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -61,7 +61,7 @@ omero_server_system_uid: 546
 omero_server_system_managedrepo_group: idr-data
 omero_server_datadir: /data/OMERO
 omero_server_datadir_bioformatscache: /data/BioFormatsCache
-
+omero_server_selfsigned_certificates: True
 omero_server_systemd_limit_nofile: 16384
 
 omero_server_python_addons:

--- a/ansible/group_vars/omeroreadwrite-hosts.yml
+++ b/ansible/group_vars/omeroreadwrite-hosts.yml
@@ -5,6 +5,7 @@
 
 omero_server_dbuser: omero
 omero_server_dbpassword: "{{ idr_secret_postgresql_password | default('omero') }}"
+omero_server_selfsigned_certificates: True
 
 idr_omero_web_timeout: 900
 

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -208,22 +208,22 @@
   - role: ome.omero_common
 
   tasks:
-    - name: Override Bio-Formats artifacts in lib/server
+    - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ idr_bf_baseurl }}/{{ item }}/{{ idr_bf_release }}/{{ item }}-{{ idr_bf_release }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item }}.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
         force: yes
-      with_items: "{{ idr_bf_components }}"
+      with_items: "{{ idr_bf_jars }}"
       notify: restart omero-server
 
-    - name: Override Bio-Formats artifacts in lib/client
+    - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ idr_bf_baseurl }}/{{ item }}/{{ idr_bf_release }}/{{ item }}-{{ idr_bf_release }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item }}.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
         force: yes
-      with_items: "{{ idr_bf_components }}"
+      with_items: "{{ omero_client_jars + idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -68,22 +68,22 @@
   - role: ome.omero_common
 
   tasks:
-    - name: Override Bio-Formats artifacts in lib/server
+    - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ idr_bf_baseurl }}/{{ item }}/{{ idr_bf_release }}/{{ item }}-{{ idr_bf_release }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item }}.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
         force: yes
-      with_items: "{{ idr_bf_components }}"
+      with_items: "{{ idr_bf_jars }}"
       notify: restart omero-server
 
-    - name: Override Bio-Formats artifacts in lib/client
+    - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ idr_bf_baseurl }}/{{ item }}/{{ idr_bf_release }}/{{ item }}-{{ idr_bf_release }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item }}.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
         force: yes
-      with_items: "{{ idr_bf_components }}"
+      with_items: "{{ omero_client_jars + idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -88,7 +88,7 @@
   version: 3.0.1
 
 - src: ome.omero_server
-  version: 4.0.0
+  version: 4.0.1
 
 - src: ome.omero_user
   version: 0.3.0


### PR DESCRIPTION
Follow-up of #329, this PR:

- installs self-signed SSL certificates on the read-write server using `omero_server_selfsigned_certificates`
- add variable to override the `lib/client` JARs and use the latest `omero-blitz/omero-romio` JARs
- updates the IDR Bio-Formats variables to use the same dictionary structure 