### PR TITLE
Install omero-figure

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -216,10 +216,12 @@ omero_web_apps_packages:
 - omero-mapr==0.4.1
 - omero-iviewer==0.10.1
 - omero-gallery==3.3.3
+- omero-figure==4.4.0
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer
 - omero_gallery
+- omero_figure
 
 omero_web_apps_top_links:
 - label: Studies

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -126,6 +126,7 @@ idr_omero_web_public_url_filters:
 - api/
 - webadmin/myphoto/
 - mapr/
+- figure/
 - iviewer/
 # Needed in OMERO.web 5.6.1 to allow the root app patch (/→/gallery)
 - '$'

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -53,6 +53,7 @@ _nginx_proxy_omero_locations:
 # /mapr/* is handled separately due to timeouts
 - /webclient/img_detail/*
 - /iviewer/*
+- /figure/*
 # Gallery is hosted at /
 - /gallery-api/*
 


### PR DESCRIPTION
Deploy omero-figure on an IDR environement.

Due to the read-only nature, figures cannot be saved back onto the server.