### PR TITLE
Reduce interval between successive groups of alters to 25m

### DIFF
--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -73,6 +73,7 @@
   - role: ome.prometheus
     prometheus_docker_network: monitoring
 
+    prometheus_alert_repeat_interval: 25m
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
     prometheus_alertmanager_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
     # The defaults in the prometheus role are (30s 5m 3h)


### PR DESCRIPTION
If OMERO services are down, this should generate alerts every 30 min

See discussion at https://github.com/IDR/deployment/pull/333. Proposing to deploy this on `prod98`