### PR TITLE
Consume ome.nginx role change disabling epel repository

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -76,7 +76,7 @@
   version: 1.0.4
 
 - name: ome.nginx
-  src: https://github.com/ome/ansible-role-nginx/archive/b8410a6551de5075054a543bd11752143767c3aa.tar.gz
+  src: https://github.com/ome/ansible-role-nginx/archive/4373dfd8bb8091a37a3e2d0401ecb72cd71fca29.tar.gz
   version: 2.1.2
 
 - src: ome.nginx_proxy

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -75,8 +75,7 @@
 - src: ome.nfs_share
   version: 1.0.4
 
-- name: ome.nginx
-  src: https://github.com/ome/ansible-role-nginx/archive/4373dfd8bb8091a37a3e2d0401ecb72cd71fca29.tar.gz
+- src: ome.nginx
   version: 2.1.2
 
 - src: ome.nginx_proxy

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -75,8 +75,9 @@
 - src: ome.nfs_share
   version: 1.0.4
 
-- src: ome.nginx
-  version: 2.1.1
+- name: ome.nginx
+  src: https://github.com/ome/ansible-role-nginx/archive/b8410a6551de5075054a543bd11752143767c3aa.tar.gz
+  version: 2.1.2
 
 - src: ome.nginx_proxy
   version: 1.15.1


### PR DESCRIPTION
Test the changes introduced in https://github.com/ome/ansible-role-nginx/pull/11.

For comparison https://github.com/IDR/deployment/runs/2858097914 (current HEAD of `origin/master`) is failing with

```
    RUNNING HANDLER [ome.nginx_proxy : restart nginx] ******************************
    fatal: [idr-ftp]: FAILED! => {"changed": false, "msg": "Unable to restart service nginx: Job for nginx.service failed because the control process exited with error code. See \"systemctl status nginx.service\" and \"journalctl -xe\" for details.\n"}
```

and

```
     RUNNING HANDLER [ome.nginx_proxy : restart nginx] ******************************
    fatal: [idr-proxy-docker]: FAILED! => {"changed": false, "msg": "Unable to restart service nginx: Job for nginx.service failed because the control process exited with error code. See \"systemctl status nginx.service\" and \"journalctl -xe\" for details.\n"}
 ```