### PR TITLE
Embassy Cloud v4: use new Openstack roles with the NFS security group

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -137,7 +137,7 @@
 # External IDR roles
 
 - name: idr.openstack_idr_instance
-  version: 3.0.2
+  version: 3.1.0
 
 - name: idr.openstack_idr_instance_network
   version: 1.1.2
@@ -149,7 +149,7 @@
   version: 3.0.1
 
 - name: idr.openstack_idr_security_groups
-  version: 1.2.1
+  version: 1.3.0
 
 
 ######################################################################

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -137,7 +137,7 @@
 # External IDR roles
 
 - name: idr.openstack_idr_instance
-  version: 3.1.0
+  version: 3.1.1
 
 - name: idr.openstack_idr_instance_network
   version: 1.1.2


### PR DESCRIPTION
The new security group is necessary to access NFS data on the Embassy Cloud v4 infrastructure