### PR TITLE
Use standard 21 port for new FTP deployment

### DIFF
--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -11,14 +11,10 @@
 
   - role: ome.anonymous_ftp
     anonymous_ftp_incoming_data_dir: /data/idrftp-incoming
-    anonymous_ftp_port: 32021
     anonymous_ftp_banner_text: |
       Welcome to the IDR upload service.
       Please upload files into "incoming/".
     anonymous_ftp_pasv_max_port: 32222
-    #anonymous_ftp_incoming_group:
-    #anonymous_ftp_emails:
-    #anonymous_ftp_public_address:
 
   tasks:
 

--- a/ansible/molecule/ftp/tests/test_default.py
+++ b/ansible/molecule/ftp/tests/test_default.py
@@ -7,9 +7,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize("port", [
-    32021,
+    21,
     32022,
-    32221,
+    32222,
 ])
 def test_listening(host, port):
     assert host.socket('tcp://%d' % port).is_listening

--- a/ansible/molecule/ftp/tests/upload_test.sh
+++ b/ansible/molecule/ftp/tests/upload_test.sh
@@ -2,7 +2,7 @@
 set -eu
 
 cd /
-ftp -p -n 127.0.0.1 32021 << EOF
+ftp -p -n 127.0.0.1 << EOF
 user anonymous allowed@example.org
 cd incoming
 put upload_test.sh

--- a/ansible/openstack-create-ftp.yml
+++ b/ansible/openstack-create-ftp.yml
@@ -16,7 +16,7 @@
   - name: IDR FTP external access security group
     os_security_group:
       description: External access to IDR FTP (managed by Ansible)
-      name: "{{ idr_environment_idr }}-ftp-external"
+      name: idr-ftp-external
       state: present
 
   - name: IDR FTP external access security group rules
@@ -26,14 +26,16 @@
       port_range_max: "{{ item.max }}"
       protocol: tcp
       remote_ip_prefix: 0.0.0.0/0
-      security_group: "{{ idr_environment_idr }}-ftp-external"
+      security_group: idr-ftp-external
       state: present
     with_items:
+    - min: 21
+      max: 21
     - min: 22
       max: 22
     - min: 443
       max: 443
-    - min: 32021
+    - min: 32022
       max: 32222
 
 
@@ -70,7 +72,7 @@
     - net-name: "{{ idr_environment_idr }}"
     idr_vm_security_groups:
     - default
-    - "{{ idr_environment_idr }}-ftp-external"
+    - idr-ftp-external
 
 
   ############################################################

--- a/docs/idr-ftp-s3.md
+++ b/docs/idr-ftp-s3.md
@@ -6,7 +6,7 @@ The IDR upload VM includes FTP and S3 services for handling data submissions.
 ## IDR FTP server
 
 The IDR FTP server runs in Docker, and only allows [passive anonymous write-only uploads](https://github.com/ome/ansible-role-anonymous-ftp/).
-The server listens on port `32021`, with data connections on ports `32022-32222`.
+The server listens on port `21`, with data connections on ports `32022-32222`.
 Incoming uploads will appear on the server under `/data/idrftp-incoming/`.
 
 


### PR DESCRIPTION
- define a single FTP security group
- add the 21 port to the FTP security group