### PR TITLE
Override idr_vm_security_groups in pilot dev server provisioning plabook

### DIFF
--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -75,6 +75,9 @@
           ((idr_network_storage | length > 0) |
             ternary([{'net-name': idr_network_storage}], []))
         }}
+      idr_vm_security_groups:
+        - 'default'
+        - 'idr-nfs-internal'
       when: idr_enable_pilotidr_devserver | default(False)
 
     - role: ome.openstack_volume_storage


### PR DESCRIPTION
This should allow the dev server need to have access to the storage for conversion purposes