### PR TITLE
Zarr server: add service playbook

### DIFF
--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -19,6 +19,3 @@
 - include: idr-proxy.yml
 - include: idr-proxy-about.yml
 - include: idr-haproxy.yml
-
-- include: idr-ftp.yml
-- include: idr-s3gateway.yml

--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -4,5 +4,8 @@
 - include: idr-ftp.yml
 - include: idr-s3gateway.yml
 
+### Export services
+- include: idr-export.yml
+
 ### TODO: Remove these in the next version
 - include: idr-downloads.yml

--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -1,4 +1,8 @@
 # Runs all playbooks for setting up services built on top of the IDR
 
+### Ingress services
+- include: idr-ftp.yml
+- include: idr-s3gateway.yml
+
 ### TODO: Remove these in the next version
 - include: idr-downloads.yml

--- a/ansible/idr-export.yml
+++ b/ansible/idr-export.yml
@@ -1,0 +1,13 @@
+# Zarr servers
+
+- hosts: "{{ idr_environment_idr }}-dev"
+
+  roles:
+    - role: ome.cli_utils
+
+  tasks:
+  - name: install Mesa libGL development package
+    become: yes
+    package:
+      name:
+        - mesa-libGL-devel

--- a/ansible/idr-export.yml
+++ b/ansible/idr-export.yml
@@ -1,6 +1,6 @@
 # Zarr servers
 
-- hosts: "{{ idr_environment_idr }}-dev"
+- hosts: "{{ idr_environment_idr | default('idr') }}-dev"
 
   roles:
     - role: ome.cli_utils

--- a/ansible/idr-export.yml
+++ b/ansible/idr-export.yml
@@ -4,6 +4,7 @@
 
   roles:
     - role: ome.cli_utils
+    - role: ome.versioncontrol_utils
 
   tasks:
   - name: install Mesa libGL development package

--- a/ansible/molecule/ftp/molecule.yml
+++ b/ansible/molecule/ftp/molecule.yml
@@ -27,7 +27,7 @@ provisioner:
     name: ansible-lint
   playbooks:
     prepare: prepare.yml
-    converge: ../../idr-01-install-idr.yml
+    converge: ../../idr-02-services.yml
   options:
     diff: True
     skip-tags: skip_if_molecule_docker

--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -65,10 +65,10 @@
       idr_vm_dockermanager: True
       idr_vm_extra_groups:
       - "{{ idr_environment_idr }}-{{ idr_vm_storage_group }}"
+      - "{{ idr_vm_storage_group }}"
       # This extra group will let us setup /etc/hosts on the proxy
       # without adding it to the parent environment
       - "{{ idr_parent_environment }}-pilotidr-hosts"
-      - "{{ idr_vm_storage_group }}"
       - "{{ idr_environment_idr }}-data-hosts"
       idr_vm_networks: >
         {{ [ {'net-name': idr_parent_environment} ] +


### PR DESCRIPTION
- create new `idr-export` service playbook to populate `{{ idr_environment_idr }}-dev` server with conversion prerequisites