### PR TITLE
Update the pilot dev server provisioning playbook to specify the volume type

### DIFF
--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -81,8 +81,9 @@
       when: idr_enable_pilotidr_devserver | default(False)
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 5000
+      openstack_volume_size: "{{ volume_size | default(5000) }}"
       openstack_volume_vmname: "{{ idr_environment_idr }}-dev"
       openstack_volume_name: data
       openstack_volume_device: /dev/vdb
+      openstack_volume_type: "{{ volume_type | default(omit) }}"
       when: idr_enable_pilotidr_devserver | default(False)

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -90,8 +90,9 @@
 - src: ome.omero_web
   version: 4.0.0
 
-- src: ome.openstack_volume_storage
-  version: 1.1.1
+- name: ome.openstack_volume_storage
+  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/b68dfa2031c42385f168ecd87107fa9c5c8cb544.tar.gz
+  version: 1.2.0
 
 - src: ome.postgresql
   version: 5.0.2

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -90,8 +90,7 @@
 - src: ome.omero_web
   version: 4.0.0
 
-- name: ome.openstack_volume_storage
-  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/b68dfa2031c42385f168ecd87107fa9c5c8cb544.tar.gz
+- src: ome.openstack_volume_storage
   version: 1.2.0
 
 - src: ome.postgresql


### PR DESCRIPTION
Consumes the parameter introduced in https://github.com/ome/ansible-role-openstack-volume-storage/pull/3