### PR TITLE
Deploy OMERO.web and OMERO.figure security release to IDR

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,14 +11,14 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.9.2
+idr_omero_web_release: 5.11.0
 # omero-web depends on omero-py but may not pin the latest release
-omero_web_python_addons:
-  - omero-py==5.9.0
+# omero_web_python_addons:
+#   - omero-py==5.9.0
 # ome.omero_server role installs omero-py but this may not be the latest release
 # TODO: This is an internal role variable, replace when we have a proper way
 # https://github.com/ome/ansible-role-omero-server/blob/3.1.0/defaults/main.yml#L89
-_omero_py_version: ==5.9.0
+# _omero_py_version: ==5.9.0
 
 artifactory_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven"
 
@@ -235,7 +235,7 @@ omero_web_apps_packages:
 - omero-mapr==0.4.1
 - omero-iviewer==0.11.1
 - omero-gallery==3.3.3
-- omero-figure==4.4.0
+- omero-figure==4.4.1
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer


### PR DESCRIPTION
See https://www.openmicroscopy.org/2021/10/14/omero-web-5.11.0.html
Also comment out the OMERO.py pinning, assuming the rolling deployment should
periodically bring the latest OMERO.py release