### PR TITLE
Openstack: handle new volume creation logic

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -90,8 +90,9 @@
 - src: ome.omero_web
   version: 4.0.1
 
-- src: ome.openstack_volume_storage
-  version: 1.2.0
+- name: ome.openstack_volume_storage
+  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/7d0b125f0d7916a5cc6422d4a5c060f5e197c942.tar.gz
+  version: 1.3.0
 
 - src: ome.postgresql
   version: 5.0.2

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -91,7 +91,7 @@
   version: 4.0.1
 
 - name: ome.openstack_volume_storage
-  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/7d0b125f0d7916a5cc6422d4a5c060f5e197c942.tar.gz
+  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/14a83bc1b1c476dcb527d356b5765186c24e5dfd.tar.gz
   version: 1.3.0
 
 - src: ome.postgresql

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -91,7 +91,6 @@
   version: 4.0.1
 
 - name: ome.openstack_volume_storage
-  src: https://github.com/ome/ansible-role-openstack-volume-storage/archive/14a83bc1b1c476dcb527d356b5765186c24e5dfd.tar.gz
   version: 1.3.0
 
 - src: ome.postgresql

--- a/scripts/os-idr-delete.py
+++ b/scripts/os-idr-delete.py
@@ -58,7 +58,6 @@ class DeleteVolumes(DeleteResource):
         super(DeleteVolumes, self).__init__(conn, wait)
         self.volumes = [v for v in conn.list_volumes()
                         if is_in_idrenv(idrenv, v)]
-        volume_ids = set(v.id for v in self.volumes)
         self.volume_snapshots = [s for s in conn.list_volume_snapshots()
                                  if is_in_idrenv(idrenv, s)]
 

--- a/scripts/os-idr-delete.py
+++ b/scripts/os-idr-delete.py
@@ -71,10 +71,10 @@ class DeleteVolumes(DeleteResource):
         )
 
     def __call__(self):
-        for s in self.volume_snapshots:
-            conn.delete_volume_snapshot(s.id, wait=self.wait)
         for v in self.volumes:
             self.conn.delete_volume(v.id, wait=self.wait)
+        for s in self.volume_snapshots:
+            conn.delete_volume_snapshot(s.id, wait=self.wait)
 
 
 class DeleteNetworks(DeleteResource):

--- a/scripts/os-idr-delete.py
+++ b/scripts/os-idr-delete.py
@@ -60,7 +60,7 @@ class DeleteVolumes(DeleteResource):
                         if is_in_idrenv(idrenv, v)]
         volume_ids = set(v.id for v in self.volumes)
         self.volume_snapshots = [s for s in conn.list_volume_snapshots()
-                                 if s.volume_id in volume_ids]
+                                 if is_in_idrenv(idrenv, s)]
 
         self.description = (
             ['Deleting Volumes'] +


### PR DESCRIPTION
--depends-on https://github.com/ome/ansible-role-openstack-volume-storage/pull/4

Following recent upstream changes in Embassy Openstack, the cloning of volumes is done via the creation of intermediate snapshots. The lifecycle of these snapshots is tightly coupled to the child volumes and the deletion script is adjusted to delete the volumes before the snapshots.