### PR TITLE
Deploy 0.2.2 tag of vsftp Docker image

### DIFF
--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -12,6 +12,7 @@
       Welcome to the IDR upload service.
       Please upload files into "incoming/".
     anonymous_ftp_pasv_max_port: 32222
+    anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.2.2
 
   tasks:
 


### PR DESCRIPTION
This should bring an up-to-date system and vsftpd version (see https://github.com/ome/vsftpd-anonymous-upload-docker/pull/7) to prevent segfaults happening on the FTP server

```
[sbesson@idrftp-ftp ~]$ sudo grep segfault /var/log/messages
Jan 18 04:14:57 idrftp-ftp kernel: vsftpd[26832]: segfault at 0 ip 0000559d4028ea7a sp 00007fffd8cbba98 error 4 in vsftpd[559d40280000+1f000]
Jan 18 17:52:06 idrftp-ftp kernel: vsftpd[11759]: segfault at 0 ip 000055d2f2797a7a sp 00007fffa19f56f8 error 4 in vsftpd[55d2f2789000+1f000]
Jan 19 07:35:30 idrftp-ftp kernel: vsftpd[18813]: segfault at 0 ip 0000557d81a5ba7a sp 00007ffe163aa018 error 4 in vsftpd[557d81a4d000+1f000]
[
```

/cc @dominikl 