### PR TITLE
Ansible 2.9 support

### DIFF
--- a/ansible/idr-ftp.yml
+++ b/ansible/idr-ftp.yml
@@ -12,7 +12,7 @@
       Welcome to the IDR upload service.
       Please upload files into "incoming/".
     anonymous_ftp_pasv_max_port: 32222
-    anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.2.3
+    # anonymous_ftp_image: openmicroscopy/vsftpd-anonymous-upload:0.2.3
 
   tasks:
 

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -173,7 +173,7 @@
     become_user: postgres
     command: psql -c 'ALTER ROLE {{ idr_omero_readonly_database.user }} SET statement_timeout = {{ idr_omero_readonly_database.statement_timeout }};'
     when: >-
-      not (omero_readonly_statement_timeout.stdout | search(
+      not (omero_readonly_statement_timeout.stdout is search(
         '[{,]statement_timeout=' + (
           idr_omero_readonly_database.statement_timeout | string) +
         '[},]'

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -85,7 +85,7 @@
       published_ports:
       - "24224:24224/udp"
       - "24224:24224"
-      restart: "{{ fluent_conf_status | changed }}"
+      restart: "{{ fluent_conf_status is changed }}"
       state: started
       restart_policy: always
       volumes:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -57,8 +57,9 @@
 - src: ome.minio_s3_gateway
   version: 0.1.1
 
-- src: ome.network_cloud_interfaces
-  version: 1.2.3
+- name: ome.network_cloud_interfaces
+  src: https://github.com/ome/ansible-role-network-cloud-interfaces/archive/1fce0679dc44c50aa163d7b5b18fe990ea1d5818.tar.gz
+  version: 1.2.4
 
 - src: ome.network
   version: 1.1.4
@@ -84,8 +85,9 @@
 - src: ome.omero_server
   version: 4.0.2
 
-- src: ome.omero_user
-  version: 0.3.0
+- name: ome.omero_user
+  src: https://github.com/ome/ansible-role-omero-user/archive/6ec1b3012dd4cc255e84341366d76b01ae852f4f.tar.gz
+  version: 0.3.1
 
 - src: ome.omero_web
   version: 4.0.1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -9,8 +9,8 @@
 - src: ome.analysis_tools
   version: 1.0.1
 
-- src: ome.anonymous_ftp
-  version: 0.1.3
+- name: ome.anonymous_ftp
+  version: 0.1.4
 
 - src: ome.basedeps
   version: 1.1.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -58,7 +58,6 @@
   version: 0.1.1
 
 - name: ome.network_cloud_interfaces
-  src: https://github.com/ome/ansible-role-network-cloud-interfaces/archive/1fce0679dc44c50aa163d7b5b18fe990ea1d5818.tar.gz
   version: 1.2.4
 
 - src: ome.network
@@ -86,7 +85,6 @@
   version: 4.0.2
 
 - name: ome.omero_user
-  src: https://github.com/ome/ansible-role-omero-user/archive/6ec1b3012dd4cc255e84341366d76b01ae852f4f.tar.gz
   version: 0.3.1
 
 - src: ome.omero_web


### PR DESCRIPTION
This PR contains as set of adjustements to the IDR playbooks to run a full deployment using Ansible 2.9. All changes are related to the usage of Ansible tests (`search`, `changed`) as filters which is dropped.

Two underlying role changes are required: https://github.com/ome/ansible-role-omero-user/pull/7 and https://github.com/ome/ansible-role-network-cloud-interfaces/pull/6