### PR TITLE
Consume IDR Bio-Formats 0.6.8 in IDR deployment

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -38,13 +38,13 @@ omero_client_jars:
 idr_bf_jars:
   - name: formats-api
     group: idr
-    version: "0.6.7"
+    version: "0.6.8"
   - name: formats-bsd
     group: idr
-    version: "0.6.7"
+    version: "0.6.8"
   - name: formats-gpl
     group: idr
-    version: "0.6.7"
+    version: "0.6.8"
 
 ice_install_devel: false
 ice_install_python: false


### PR DESCRIPTION
Includes the OME-TIFF improvements from https://github.com/IDR/bioformats/pull/27