### PR TITLE
Idr gallery config

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,7 +11,7 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.14.0.rc1
+idr_omero_web_release: 5.14.0
 # omero-web depends on omero-py but may not pin the latest release
 # omero_web_python_addons:
 #   - omero-py==5.9.0
@@ -236,7 +236,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- omero-mapr==0.5rc1
+- omero-mapr==0.5.0
 - omero-iviewer==0.11.3
 - git+https://github.com/IDR/idr-gallery.git@refs/pull/2/head
 - omero-figure==4.4.3

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -149,6 +149,9 @@ idr_omero_web_public_url_filters:
 - iviewer/
 # Needed in OMERO.web 5.6.1 to allow the root app patch (/→/gallery)
 - '$'
+- search/
+- search/cell/
+- search/tissue/
 - gallery-api/
 - gallery_settings/
 - cell/

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -537,9 +537,9 @@ omero_web_apps_config_set:
   omero.web.gallery.footer_html: "IDR"
   omero.web.gallery.category_queries:
     latest:
-      label: "Most Recent"
+      label: "Light sheet fluorescence microscopy"
       index: 0
-      query: "LAST10:date"
+      query: "Imaging Method: light sheet fluorescence microscopy OR Imaging Method: light sheet fluorescence microscopy, SPIM"
     infection:
       label: "Infection studies"
       index: 1
@@ -568,6 +568,10 @@ omero_web_apps_config_set:
       label: "High-content screening (human)"
       index: 7
       query: "Organism:Homo sapiens AND Study Type:high content screen"
+    others:
+      label: "Others"
+      index: 8
+      query: "LAST1000:date"
   omero.web.gallery.filter_keys:
   - label: "Name (IDR number)"
     value: "Name"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -238,7 +238,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.5.0
 - omero-iviewer==0.11.3
-- git+https://github.com/IDR/idr-gallery.git@refs/pull/2/head
+- idr-gallery==3.5.0
 - omero-figure==4.4.3
 omero_web_apps_names:
 - omero_mapr

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -147,7 +147,7 @@ idr_omero_web_public_url_filters:
 - mapr/
 - figure/
 - iviewer/
-# Needed in OMERO.web 5.6.1 to allow the root app patch (/→/gallery)
+# Needed in OMERO.web 5.6.1 to allow the root app patch (/→/idr_gallery)
 - '$'
 - search/
 - search/cell/
@@ -206,7 +206,7 @@ omero_web_config_set:
     default:
       BACKEND: django_redis.cache.RedisCache
       LOCATION: redis://{{ omero_redis_host_ansible | default('127.0.0.1') }}:6379/0
-  # / goes to gallery
+  # / goes to idr_gallery
   omero.web.root_application: idr_gallery
   # social media
   omero.web.sharing.twitter:
@@ -238,12 +238,12 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.5rc1
 - omero-iviewer==0.11.3
-- omero-gallery==3.4.2
+- git+https://github.com/IDR/idr-gallery.git@refs/pull/2/head
 - omero-figure==4.4.3
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer
-- omero_gallery
+- idr_gallery
 - omero_figure
 
 omero_web_apps_top_links:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -204,7 +204,7 @@ omero_web_config_set:
       BACKEND: django_redis.cache.RedisCache
       LOCATION: redis://{{ omero_redis_host_ansible | default('127.0.0.1') }}:6379/0
   # / goes to gallery
-  omero.web.root_application: gallery
+  omero.web.root_application: idr_gallery
   # social media
   omero.web.sharing.twitter:
     omero: "@openmicroscopy"


### PR DESCRIPTION
With https://github.com/IDR/idr-gallery/pull/2, the 'root' (app to appear at the home page) is now `idr_gallery`.

Also, this adds "Light sheet fluorescence microscopy" as a category (now found under "Group Studies by type").

This is currently deployed for testing and seems to be working fine:
 - The / home URL is pointing to `idr_gallery` and the app is installed OK.
 - /cell/search/ and related URLs added to public url filter are working
 - the "Lightsheet microscopy" category and "Others" category are showing correctly under "Group Studies by Type"

NB: now that the PR above includes all the current config as default IDR behaviour, we don't need it in `omero-hosts.yml` unless we need to update it.