### PR TITLE
Bump OMERO.web and apps to versions compatible with Django 3.2

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -11,7 +11,7 @@
 idr_omero_server_release: 5.6.0
 omero_server_checkupgrade_comparator: '!='
 
-idr_omero_web_release: 5.13.0
+idr_omero_web_release: 5.14.0.rc1
 # omero-web depends on omero-py but may not pin the latest release
 # omero_web_python_addons:
 #   - omero-py==5.9.0
@@ -233,10 +233,10 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- omero-mapr==0.4.2
-- omero-iviewer==0.11.1
-- omero-gallery==3.3.3
-- omero-figure==4.4.1
+- omero-mapr==0.5rc1
+- omero-iviewer==0.11.3
+- omero-gallery==3.4.1
+- omero-figure==4.4.3
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -235,7 +235,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.5rc1
 - omero-iviewer==0.11.3
-- omero-gallery==3.4.1
+- omero-gallery==3.4.2
 - omero-figure==4.4.3
 omero_web_apps_names:
 - omero_mapr


### PR DESCRIPTION
See https://www.openmicroscopy.org/2022/02/18/omeroweb-django-upgrade.html