### PR TITLE
Defined new group for deploying the searchengine in the pilot IDRs

### DIFF
--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -30,6 +30,8 @@
       # these hosts in the individual pilot environments
       - "{{ idr_parent_environment }}-pilotomero-hosts"
       - "{{ idr_parent_environment }}-pilotdatabase-hosts"
+      # This extra group controls the deployment of the searchengine app
+      - "{{ idr_parent_environment }}-searchengine-hosts"
       idr_vm_networks: >
         {{ [ {'net-name': idr_parent_environment} ] +
           ((idr_network_storage | length > 0) |


### PR DESCRIPTION
Related to #359, the next step discussed at the weekly IDR meeting is to deploy the searchengine stack (Elasticsearch, searchengine app, searchengineclient) in a pilot  environment.

So far all the deployment has been happening through the `management` VM which contains the monitoring stack. This was always understood to be a staging location allowing ourselves to assess the prototype. As we are looking into moving the searchengine API into production, a few requirements need to be considered immediately:

- the searchengine should be deployable into pilots i.e. as part of the validation workflow
- the indexing/caching step needs additional memory capabilities to run in a performant manner
- in a production environment, the searchengine endpoint will also need to be available internally at the level of each OMERO deployment (as opposed to only at the proxy level currently).

Deploying the search engine in a single-node pilot context will allow us to evaluate this production deployment.

To do so, this PR defines a new group `"{{ idr_parent_environment }}-searchengine-hosts"` associated with the individual pilot OMERO VMs. Once deployed in a test pilot instance, the playbook in #359 can be adjusted to run on this group rather than `"{{ idr_parent_environment }}-management-hosts"` and also increase the number of rows that can be indexed. /cc @khaledk2