### PR TITLE
Update playbooks to deploy searchengine in production deployment

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -100,11 +100,18 @@ _nginx_proxy_backends_prometheus_federate:
   server: "http://{{ management_host_ansible | default('localhost') }}:9090/federate"
   cache_validity: 15s
 
+_nginx_proxy_backends_searchengineapi:
+- name: searchengineapi
+  location: "^~ /searchengineapi"
+  server: "http://{{ searchengine_host_ansible | default('localhost') }}:5577/searchengineapi"
+  host_header: "$host/searchengine"
+
 nginx_proxy_backends: >
   {{ _nginx_proxy_backends_omero +
      _nginx_proxy_backends_omerowebsockets +
      _nginx_proxy_backends_grafana_render +
-     _nginx_proxy_backends_prometheus_federate
+     _nginx_proxy_backends_prometheus_federate +
+     _nginx_proxy_backends_searchengineapi
   }}
 
 

--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -9,3 +9,6 @@
 
 ### Transfer services
 - include: idr-transfer.yml
+
+## Search services
+- include: idr-searchengine.yml

--- a/ansible/idr-proxy.yml
+++ b/ansible/idr-proxy.yml
@@ -8,9 +8,13 @@
     {{ idr_environment | default('idr') }}-omero-hosts
 
 
-# Load hostvars (managment server)
+# Load hostvars (management server)
 - hosts: >
     {{ idr_environment | default('idr') }}-management-hosts
+
+# Load hostvars (search engine server)
+- hosts: >
+    {{ idr_environment | default('idr') }}-searchengine-hosts
 
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
@@ -62,6 +66,16 @@
             ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
         }}
     when: groups[idr_environment | default('idr') + '-management-hosts'] is defined
+
+  - name: Get search engine server IP
+    set_fact:
+      searchengine_host_ansible: >-
+        {{
+          hostvars[groups[
+            idr_environment | default('idr') + '-searchengine-hosts'][0]]
+            ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+        }}
+    when: groups[idr_environment | default('idr') + '-searchengine-hosts'] is defined
 
   roles:
   # Default to a self-signed certificate

--- a/ansible/idr-searchengine.yml
+++ b/ansible/idr-searchengine.yml
@@ -8,7 +8,12 @@
   tasks:
   - name: Get database host
     set_fact:
-      database_server_url: "{{ hostvars[groups[idr_environment | default('idr') + '-database-hosts'][0]]['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']}}"
+      database_server_url: >-
+        {{
+          hostvars[groups[idr_environment | default('idr') + '-database-hosts'][0]]
+          ['ansible_' + (idr_net_iface | default('eth0'))]['ipv4']['address']
+        }}
+
   - name: Create app top level directory
     become: yes
     file:
@@ -17,6 +22,7 @@
       state: directory
       owner: root
       group: root
+      mode: 0755
 
   - name: Create searchengine folder directory
     become: yes
@@ -26,18 +32,21 @@
       state: directory
       owner: root
       group: root
-      
+      mode: 0755
+
   - name: Create searchengine logs directory
     become: yes
     file:
       path: "{{ apps_folder }}/searchengine/searchengine/logs"
       state: directory
+      mode: 0755
 
   - name: Create searchengine cached directory
     become: yes
     file:
       path: "{{ apps_folder }}/searchengine/searchengine/cacheddata"
       state: directory
+      mode: 0755
 
   - name: Create client  directory
     become: yes
@@ -47,6 +56,7 @@
       state: directory
       owner: root
       group: root
+      mode: 0755
 
   - name: Create client data directory
     become: yes
@@ -56,12 +66,14 @@
       state: directory
       owner: root
       group: root
+      mode: 0755
 
   - name: Create client logs directory
     become: yes
     file:
       path: "{{ apps_folder }}/searchengine/client/logs"
       state: directory
+      mode: 0755
 
   - name: Create elasticsearch directory
     become: yes
@@ -71,7 +83,8 @@
       # User id in elasticsearch Docker image
       owner: 1000
       group: root
-      
+      mode: 0755
+
   - name: Create elasticsearch logs directory
     become: yes
     file:
@@ -80,6 +93,7 @@
       # User id in elasticsearch Docker image
       owner: 1000
       group: root
+      mode: 0755
 
   - name: Create elasticsearch data directory
     become: yes
@@ -89,6 +103,7 @@
       # User id in elasticsearch Docker image
       owner: 1000
       group: root
+      mode: 0755
 
   - name: Create docker network
     become: yes
@@ -110,7 +125,7 @@
     docker_container:
       image: "{{ search_engineelasticsearch_docker_image }}"
       name: searchengineelasticsearch
-      cleanup: True      
+      cleanup: True
       env:
          discovery.type: single-node
          path.data: /var/lib/elasticsearch
@@ -130,7 +145,7 @@
       volumes:
       - "{{ apps_folder }}/searchengine/elasticsearch{{ apps_folder }}:/var/lib/elasticsearch"
       - "{{ apps_folder }}/searchengine/elasticsearch/logs:/var/log/elasticsearch"
-      - 
+
   - name: configure elasticsearch  for docker searchengine
     become: yes
     docker_container:
@@ -147,7 +162,6 @@
       volumes:
       - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
 
- 
   - name: configure database for docker searchengine
     become: yes
     docker_container:
@@ -155,7 +169,9 @@
       name: searchengine_database
       cleanup: True
       #auto_remove: yes
-      command: "set_database_configuration -u {{ database_server_url }}  -d {{ database_name }} -s {{ database_port }} -n {{ database_username }} -p {{ database_user_password }}"
+      command: >
+        set_database_configuration -u {{ database_server_url }}
+        -d {{ database_name }} -s {{ database_port }} -n {{ database_username }} -p {{ database_user_password }}
       #networks:
       #- name: searchengine-net
       #published_ports:
@@ -163,7 +179,7 @@
       state: started
       volumes:
       - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
- 
+
   - name: configure cache folder  for docker searchengine
     become: yes
     docker_container:
@@ -264,7 +280,7 @@
   - name: Run docker searchengine
     become: yes
     docker_container:
-      image: "{{ searchengine_docker_image}}"
+      image: "{{ searchengine_docker_image }}"
       name: searchengine
       cleanup: True
       command: "run_app {{ searchengineurlprefix }}"
@@ -285,7 +301,7 @@
     docker_container:
       image: "{{ searchengineclient_docker_image }}"
       name: searchengineclient
-      cleanup: True       
+      cleanup: True
       networks:
       - name: searchengine-net
       published_ports:

--- a/ansible/idr-searchengine.yml
+++ b/ansible/idr-searchengine.yml
@@ -119,7 +119,6 @@
          cluster.name: docker-cluster
          http.host: 0.0.0.0
          #http.port: 9200
-         discovery.type: single-node
          ES_JAVA_OPTS: "-Xmx4096m"
       networks:
       - name: searchengine-net

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -167,5 +167,4 @@
       openstack_volume_vmname: "{{ idr_environment_idr }}-searchengine"
       openstack_volume_name: "{{ idr_environment_idr }}-searchengine-data"
       openstack_volume_device: /dev/vdb
-      openstack_volume_source: "{{ idr_volume_searchengine_data_src | default(omit) }}"
       openstack_volume_type: "{{ idr_volume_searchengine_data_type | default(omit) }}"

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -144,3 +144,28 @@
       openstack_volume_vmname: "{{ idr_environment_idr }}-management"
       openstack_volume_name: "{{ idr_environment_idr }}-management-data"
       openstack_volume_device: /dev/vdb
+
+    ############################################################
+    # Search engine instances
+
+    # Dedicated search engine server
+    - role: idr.openstack_idr_instance
+      idr_environment: "{{ idr_environment_idr }}"
+      idr_vm_name: "{{ idr_environment_idr }}-searchengine"
+      idr_vm_image: "{{ vm_image }}"
+      idr_vm_flavour: "{{ vm_flavour_large }}"
+      idr_vm_dockerworker: True
+      idr_vm_extra_groups:
+      - searchengine-hosts
+      - "{{ idr_environment_idr }}-searchengine-hosts"
+      idr_vm_networks:
+      - net-name: "{{ idr_environment_idr }}"
+
+    # Search engine Volume
+    - role: ome.openstack_volume_storage
+      openstack_volume_size: 75
+      openstack_volume_vmname: "{{ idr_environment_idr }}-searchengine"
+      openstack_volume_name: "{{ idr_environment_idr }}-searchengine-data"
+      openstack_volume_device: /dev/vdb
+      openstack_volume_source: "{{ idr_volume_searchengine_data_src | default(omit) }}"
+      openstack_volume_type: "{{ idr_volume_searchengine_data_type | default(omit) }}"

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -158,6 +158,7 @@
       idr_vm_extra_groups:
       - searchengine-hosts
       - "{{ idr_environment_idr }}-searchengine-hosts"
+      - "{{ idr_environment_idr }}-data-hosts"
       idr_vm_networks:
       - net-name: "{{ idr_environment_idr }}"
 


### PR DESCRIPTION
Fixes #370

As discussed on the issue, this PR implements option 3 and creates a new VM of similar compute capacity to `omeroreadwrite` and some dedicated storage.

To be deployed on `test107`