### PR TITLE
Install omero_search_engine_client from github

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -614,4 +614,4 @@ omero_web_apps_config_set:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"
     template: "$1$2"
-  omero.web.searchengine.url: "searchengineapi/api/v1"
+  omero.web.searchengine.url: "searchengineapi/v1"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -147,6 +147,7 @@ idr_omero_web_public_url_filters:
 - mapr/
 - figure/
 - iviewer/
+- search_engine/
 # Needed in OMERO.web 5.6.1 to allow the root app patch (/→/idr_gallery)
 - '$'
 - search/
@@ -240,11 +241,14 @@ omero_web_apps_packages:
 - omero-iviewer==0.11.3
 - idr-gallery==3.6.1
 - omero-figure==4.4.3
+- git+https://github.com/ome/omero_search_engine_client
 omero_web_apps_names:
 - omero_mapr
 - omero_iviewer
 - idr_gallery
 - omero_figure
+- omero_search_engine_client
+
 
 omero_web_apps_top_links:
 - label: Studies

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -614,4 +614,4 @@ omero_web_apps_config_set:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"
     template: "$1$2"
-  omero.web.searchengine.url: "searchengineapi/v1"
+  omero.web.searchengine.url: "searchengine/api/v1"

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -614,3 +614,4 @@ omero_web_apps_config_set:
   - key: "Name"
     regex: "^(.*?)-.*?(.)$"
     template: "$1$2"
+  omero.web.searchengine.url: "searchengineapi/api/v1"


### PR DESCRIPTION
This adds omero_search_engine_client as a web-app to IDR deployment, initially installing from github since it's not on pypi yet.

The `omero_client_search_engine` code can then be consumed by `omero-web` e.g. https://github.com/ome/omero-web/pull/368

This will allow manual update of the app on idr-testing from a current branch, as I currently do for e.g. gallery so that currently opened PRs can be tested e.g.

```
for server in omeroreadwrite omeroreadonly-1 omeroreadonly-2 omeroreadonly-3 omeroreadonly-4; do ssh $server "sudo /opt/omero/web/venv3/bin/pip uninstall -y idr-gallery && sudo /opt/omero/web/venv3/bin/pip install git+https://github.com/IDR/idr-gallery.git@refs/pull/8/head && sudo service omero-web restart"; done
```

