### PR TITLE
Remove all the references to the search engine client deployment

### DIFF
--- a/ansible/group_vars/searchengine-hosts.yml
+++ b/ansible/group_vars/searchengine-hosts.yml
@@ -7,11 +7,9 @@ database_user_password:  "{{ idr_secret_postgresql_password_ro | default('omero'
 searchenginecache_folder: /data/searchengine/searchengine/cacheddata/
 search_engineelasticsearch_docker_image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
 searchengine_docker_image: openmicroscopy/omero-searchengine:latest
-searchengineclient_docker_image: openmicroscopy/omero-searchengineclient:latest
 #ansible_python_interpreter: path/to/bin/python
 searchengine_index: searchengine_index
 cache_rows: 100000
 # I think that the following two variables should be in secret
 searchengine_secret_key: "fagfdssf3fgdnvhg56ghhgfhgfgh45f"
-searchengineclient_secret_key: "gfdgfdggregb3tyttnmnymytmasfd"
 searchengineurlprefix: "searchengineapi"

--- a/ansible/idr-searchengine.yml
+++ b/ansible/idr-searchengine.yml
@@ -1,4 +1,4 @@
-# Search ngine + Search Engine Client + Elasticsearch
+# Search ngine +  Elasticsearch
 
 - hosts: "{{ idr_environment | default('idr') }}-database-hosts"
 
@@ -45,33 +45,6 @@
     become: yes
     file:
       path: "{{ apps_folder }}/searchengine/searchengine/cacheddata"
-      state: directory
-      mode: 0755
-
-  - name: Create client  directory
-    become: yes
-    file:
-      path: "{{ apps_folder }}/searchengine/client"
-      recurse: yes
-      state: directory
-      owner: root
-      group: root
-      mode: 0755
-
-  - name: Create client data directory
-    become: yes
-    file:
-      path: "{{ apps_folder }}/searchengine/client/app_data"
-      recurse: yes
-      state: directory
-      owner: root
-      group: root
-      mode: 0755
-
-  - name: Create client logs directory
-    become: yes
-    file:
-      path: "{{ apps_folder }}/searchengine/client/logs"
       state: directory
       mode: 0755
 
@@ -236,47 +209,6 @@
       volumes:
       - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
 
-  - name: configure search engine url for search client
-    become: yes
-    docker_container:
-      image: "{{ searchengineclient_docker_image }}"
-      name: searchengineclient_search_uri
-      cleanup: True
-      #auto_remove: yes
-      command: "set_searchengine_url -u http://searchengine:5577/"# http://127.0.0.1:5556/"
-      #networks:
-      #- name: searchengine-net
-      #published_ports:
-      #- "5567:5567"
-      state: started
-      volumes:
-      - "{{ apps_folder }}/searchengine/client:/etc/searchengineclient/"
-
-  - name: configure secret key for search client
-    become: yes
-    docker_container:
-      image: "{{ searchengineclient_docker_image }}"
-      name: searchengineclient_search_uri
-      cleanup: True
-      #auto_remove: yes
-      command: "set_client_secret_key -s {{ searchengineclient_secret_key }}"
-      state: started
-      volumes:
-      - "{{ apps_folder }}/searchengine/client:/etc/searchengineclient/"
-
-  - name: configure app data folder for search client
-    become: yes
-    docker_container:
-      image: "{{ searchengineclient_docker_image }}"
-      name: searchengineclient_search_uri
-      cleanup: True
-      #auto_remove: yes
-      command: "set_app_data_folder -a /etc/searchengineclient/app_data"
-      state: started
-      volumes:
-        - "{{ apps_folder }}/searchengine/client:/etc/searchengineclient/"
-
-
   - name: Run docker searchengine
     become: yes
     docker_container:
@@ -294,21 +226,3 @@
       volumes:
         - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
         - "{{ apps_folder }}/searchengine/searchengine/cachedata:/etc/searchengine/cachedata"
-
-
-  - name: Run docker searchengineclient
-    become: yes
-    docker_container:
-      image: "{{ searchengineclient_docker_image }}"
-      name: searchengineclient
-      cleanup: True
-      networks:
-      - name: searchengine-net
-      published_ports:
-      - "5567:5567"
-      #restart: "{{ searchengineclient_conf_status | changed }}"
-      state: started
-      restart_policy: always
-      volumes:
-        - "{{ apps_folder }}/searchengine/client:/etc/searchengineclient/"
-        - "{{ apps_folder }}/searchengine/client/app_data:/etc/searchengineclient/app_data"


### PR DESCRIPTION
This PR removes all the references to the search engine client deployment as it has been added as a web app to IDR deployment so there is no point in including it.