### PR TITLE
Bump omeroreadwrite data volume to 1.5TB

### DIFF
--- a/ansible/openstack-create-pilotidr-servers.yml
+++ b/ansible/openstack-create-pilotidr-servers.yml
@@ -50,7 +50,7 @@
       when: idr_enable_pilotidr_omero | default(False)
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 1200
+      openstack_volume_size: 1500
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: "{{ idr_environment_idr }}-omeroreadwrite-data"
       openstack_volume_device: /dev/vdc

--- a/ansible/openstack-create-publicidr.yml
+++ b/ansible/openstack-create-publicidr.yml
@@ -107,7 +107,7 @@
       openstack_volume_source: "{{ idr_volume_database_db_src }}"
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 1200
+      openstack_volume_size: 1500
       openstack_volume_vmname: "{{ idr_environment_idr }}-omeroreadwrite"
       openstack_volume_name: "{{ idr_environment_idr }}-omeroreadwrite-data"
       openstack_volume_device: /dev/vdb

--- a/ansible/openstack-create-volumes.yml
+++ b/ansible/openstack-create-volumes.yml
@@ -29,7 +29,7 @@
       when: idr_enable_pilotidr_omero | default(False)
 
     - role: ome.openstack_volume_storage
-      openstack_volume_size: 1200
+      openstack_volume_size: 1500
       openstack_volume_name: "{{ idr_environment_idr }}-omeroreadwrite-data"
       openstack_volume_source: "{{ idr_volume_omero_data_src }}"
       openstack_volume_wait: False


### PR DESCRIPTION
Routine expansion of the OMERO data volume as the imported data grows to bring the data usage below the 80% threshold