### PR TITLE
add task to configure  IDR_TEST_FILE_URL

### DIFF
--- a/ansible/group_vars/searchengine-hosts.yml
+++ b/ansible/group_vars/searchengine-hosts.yml
@@ -13,3 +13,4 @@ cache_rows: 100000
 # I think that the following two variables should be in secret
 searchengine_secret_key: "fagfdssf3fgdnvhg56ghhgfhgfgh45f"
 searchengineurlprefix: "searchengine"
+IDR_TEST_FILE_URL: "https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv"

--- a/ansible/idr-searchengine.yml
+++ b/ansible/idr-searchengine.yml
@@ -153,6 +153,18 @@
       volumes:
       - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
 
+  - name: configure IDR_TEST_FILE_URL item
+    become: yes
+    docker_container:
+      image: "{{ searchengine_docker_image }}"
+      name: searchengine_IDR_TEST_FILE
+      cleanup: True
+      command: "set_idr_test_file -i {{ IDR_TEST_FILE_URL }}"
+      state: started
+      volumes:
+      - "{{ apps_folder }}/searchengine/searchengine/:/etc/searchengine/"
+
+
   - name: configure cache folder  for docker searchengine
     become: yes
     docker_container:


### PR DESCRIPTION
Although this configuration item has a default value in the app configuration file, we may need to refer to another file  for verification rather than the default one `https://raw.githubusercontent.com/IDR/idr.openmicroscopy.org/master/_data/studies.tsv `