### PR TITLE
Configure self-signed certificates on all OMERO hosts

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -110,6 +110,7 @@ omero_server_config_set:
   # Disable all components except Blitz and Tables
   omero.server.nodedescriptors: "master:Blitz-0,Tables-0"
 
+omero_server_selfsigned_certificates: True
 
 ######################################################################
 # Other dependent role vars

--- a/ansible/group_vars/omeroreadonly-hosts.yml
+++ b/ansible/group_vars/omeroreadonly-hosts.yml
@@ -6,7 +6,6 @@
 omero_server_dbuser: omeroreadonly
 omero_server_dbpassword: "{{ idr_secret_postgresql_password_ro | default('omero') }}"
 
-omero_server_datadir_manage: False
 idr_omero_web_user_dropdown: false
 
 # Set this to 'ro' to mount /data/BioFormatsCache on read-only servers as

--- a/ansible/group_vars/omeroreadwrite-hosts.yml
+++ b/ansible/group_vars/omeroreadwrite-hosts.yml
@@ -5,7 +5,6 @@
 
 omero_server_dbuser: omero
 omero_server_dbpassword: "{{ idr_secret_postgresql_password | default('omero') }}"
-omero_server_selfsigned_certificates: True
 
 idr_omero_web_timeout: 900
 

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -89,13 +89,10 @@
     become: yes
     copy:
       content: |
-        config set -- omero.data.dir /data/OMERO
         config set -- omero.cluster.read_only true
       dest: /opt/omero/server/config/omero-readonly-config.omero
       force: yes
       mode: 0644
-    notify:
-    - restart omero-server if installed
 
   # There are several bugs- read-only still needs write access to several
   # directories including ManagedRepository/.omero


### PR DESCRIPTION
The self-signed SSL certificates were initially deployed on the read-write hosts to fix import issues but they might be required on all read-only servers to fix access via the Java API