### PR TITLE
Replace deprecated include directive by import_playbook

### DIFF
--- a/ansible/decommission/playbook.yml
+++ b/ansible/decommission/playbook.yml
@@ -21,6 +21,6 @@
       when: floating_ip == idr_prod_ip
 
 
-- include: archive-db.yml
-- include: archive-instance-services.yml
-- include: archive-logs.yml
+- import_playbook: archive-db.yml
+- import_playbook: archive-instance-services.yml
+- import_playbook: archive-logs.yml

--- a/ansible/idr-00-preinstall.yml
+++ b/ansible/idr-00-preinstall.yml
@@ -1,12 +1,12 @@
 # Runs all storage related playbooks for setting up the IDR infrastructure
 # This will be specific to your Openstack and local environment
 
-- include: idr-networks.yml
+- import_playbook: idr-networks.yml
 
-- include: idr-centos-init.yml
-- include: idr-upgrade-dist.yml
-- include: os-idr-volumes.yml
-- include: idr-dundee-nfs.yml
-- include: idr-ebi-nfs.yml
+- import_playbook: idr-centos-init.yml
+- import_playbook: idr-upgrade-dist.yml
+- import_playbook: os-idr-volumes.yml
+- import_playbook: idr-dundee-nfs.yml
+- import_playbook: idr-ebi-nfs.yml
 
-- include: idr-reboot-if-kernel.yml
+- import_playbook: idr-reboot-if-kernel.yml

--- a/ansible/idr-01-install-idr.yml
+++ b/ansible/idr-01-install-idr.yml
@@ -2,20 +2,20 @@
 # environment. This does not run any storage/networking/cloud specific
 # tasks, nor does it run playbooks requiring private configuration
 
-- include: idr-hosts.yml
+- import_playbook: idr-hosts.yml
 
-- include: idr-firewall.yml
+- import_playbook: idr-firewall.yml
 
-- include: idr-omero.yml
-- include: idr-omero-web.yml
+- import_playbook: idr-omero.yml
+- import_playbook: idr-omero-web.yml
 
-- include: idr-omero-readonly.yml
+- import_playbook: idr-omero-readonly.yml
   tags:
   # Requires NFS shares which can't be configured in Docker
   - skip_if_molecule_docker
 
-- include: idr-docker.yml
+- import_playbook: idr-docker.yml
 
-- include: idr-proxy.yml
-- include: idr-proxy-about.yml
-- include: idr-haproxy.yml
+- import_playbook: idr-proxy.yml
+- import_playbook: idr-proxy-about.yml
+- import_playbook: idr-haproxy.yml

--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -1,14 +1,14 @@
 # Runs all playbooks for setting up services built on top of the IDR
 
 ### Ingress services
-- include: idr-ftp.yml
-- include: idr-s3gateway.yml
+- import_playbook: idr-ftp.yml
+- import_playbook: idr-s3gateway.yml
 
 ### Export services
-- include: idr-export.yml
+- import_playbook: idr-export.yml
 
 ### Transfer services
-- include: idr-transfer.yml
+- import_playbook: idr-transfer.yml
 
 ## Search services
-- include: idr-searchengine.yml
+- import_playbook: idr-searchengine.yml

--- a/ansible/idr-03-postinstall.yml
+++ b/ansible/idr-03-postinstall.yml
@@ -1,3 +1,3 @@
 # IDR post-installation playbooks
 
-- include: idr-reset-users-groups.yml
+- import_playbook: idr-reset-users-groups.yml

--- a/ansible/idr-09-monitoring.yml
+++ b/ansible/idr-09-monitoring.yml
@@ -1,7 +1,7 @@
 # IDR post-installation playbooks
 # Some of this requires private configuration information
 
-- include: management.yml
-- include: management-prometheus.yml
-- include: management-grafana.yml
-- include: management-fluentd.yml
+- import_playbook: management.yml
+- import_playbook: management-prometheus.yml
+- import_playbook: management-grafana.yml
+- import_playbook: management-fluentd.yml

--- a/ansible/openstack-create-infrastructure.yml
+++ b/ansible/openstack-create-infrastructure.yml
@@ -1,23 +1,23 @@
 # Parent provisioning playbook
 
 # This manages the production IDR servers
-- include: openstack-create-publicidr.yml
+- import_playbook: openstack-create-publicidr.yml
   when: 'idr_enable_publicidr | default(True)'
 
 # Pilot IDR: Gateway proxy + network infrastructure for all OMERO servers
-- include: openstack-create-pilotidr.yml
+- import_playbook: openstack-create-pilotidr.yml
   when: 'idr_enable_pilotidr | default(False)'
 
-# Pilot IDR: various testing servers include single OMERO and dev docker
-- include: openstack-create-pilotidr-servers.yml
+# Pilot IDR: various testing servers import_playbook single OMERO and dev docker
+- import_playbook: openstack-create-pilotidr-servers.yml
   when: >-
     (idr_enable_pilotidr_omero | default(False)) or
     (idr_enable_pilotidr_devserver | default(False))
 
 # Independent anonymous FTP server
-- include: openstack-create-ftp.yml
+- import_playbook: openstack-create-ftp.yml
   when: 'idr_enable_ftp | default(True)'
 
 # Independent anonymous GHA server
-- include: openstack-create-gha.yml
+- import_playbook: openstack-create-gha.yml
   when: 'idr_enable_gha | default(False)'


### PR DESCRIPTION
Updates the IDR playbooks as these directives will be dropped in Ansible 2.12