### PR TITLE
Refactor updates to the IDR static website

### DIFF
--- a/ansible/files/deploy
+++ b/ansible/files/deploy
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shutil
+import sys
+import tarfile
+# Python 2 and 3 compatible so this can be run on RHEL7 without a virtualenv
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+
+def main(version, parent, dry_run):
+    # https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#releases
+    # No paging, assume no-one will install a really old version
+    r = urlopen('https://api.github.com/repos/IDR/idr.openmicroscopy.org/releases')
+    assert r.code == 200
+    releases = json.load(r)
+
+    if version == 'latest':
+        release = releases[0]
+    else:
+        release = None
+        for check in releases:
+            if check['tag_name'] == version:
+                release = check
+                break
+        if release is None:
+            print('Failed to find release {}'.format(version))
+            sys.exit(1)
+
+    tag = release['tag_name']
+
+    version_source_file = os.path.join(parent, 'VERSION')
+    if not os.path.exists(version_source_file):
+        print(f"Missing version file at {version_file}")
+
+    dst = os.path.join(parent, tag)
+    sym = os.path.join(parent, 'html')
+
+    if os.path.exists(dst):
+        print('{} already exists, not downloading'.format(dst))
+    elif dry_run:
+        print('Would download {}'.format(dst))
+    else:
+        www_assets = [a for a in release['assets'] if a['name'] == 'idr.openmicroscopy.org.tar.gz']
+        assert len(www_assets) == 1, 'Expected one asset named idr.openmicroscopy.org.tar.gz'
+        url = www_assets[0]['browser_download_url']
+
+        h = urlopen(url)
+        thetarfile = tarfile.open(fileobj=h, mode="r|gz")
+        thetarfile.extractall(path=dst)
+        h.close()
+        print('Extracted {} to {}'.format(url, dst))
+        
+        version_dst_file = os.path.join(dst, "VERSION")
+        shutil.copyfile(version_source_file, version_dst_file)
+        print('Copied {} to {}'.format(version_source_file, version_dst_file))
+
+    if os.path.exists(sym):
+        assert os.path.islink(sym), '{} is not a symlink'.format(sym)
+        target = os.readlink(sym)
+        if target == dst:
+            print('{} already points to {}, no changes made'.format(dst, sym))
+            sys.exit(0)
+        elif dry_run:
+            print('Would remove symlink {} (target={})'.format(sym, target))
+        else:
+            print(target)
+            # Mutator
+            os.remove(sym)
+    if dry_run:
+        print('Would symlink {} to {}'.format(dst, sym))
+    else:
+        # Mutator
+        os.symlink(dst, sym)
+        print('Symlinked {} to {}'.format(dst, sym))
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    xor = parser.add_mutually_exclusive_group()
+    xor.add_argument('-n','--dry-run', action='store_true', default=True)
+    xor.add_argument('-f','--force', action='store_false', dest="dry_run")
+    parser.add_argument(
+        '--parentdir', default='/srv/www/',
+        help='Web-server directory for idr.openmicroscopy.org')
+    parser.add_argument('--version', default='latest',
+        help='Release to download')
+    args = parser.parse_args()
+    main(args.version, args.parentdir, args.dry_run)

--- a/ansible/files/deploy
+++ b/ansible/files/deploy
@@ -73,11 +73,12 @@ def main(version, parent, dry_run):
             os.remove(sym)
     if dry_run:
         print('Would symlink {} to {}'.format(dst, sym))
+        sys.exit(1)
     else:
         # Mutator
         os.symlink(dst, sym)
         print('Symlinked {} to {}'.format(dst, sym))
-    sys.exit(1)
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -357,22 +357,6 @@ idr_backend_reserved_offset: 2
 idr_haproxy_frontend_omero_offset: 14060
 idr_haproxy_frontend_omero_host: idr.openmicroscopy.org
 
-
-######################################################################
-# Static webpages (/about) on proxy
-
-idr_openmicroscopy_org_version: 2023.01.27
-deploy_archive_dest_dir: /srv/www/{{ idr_openmicroscopy_org_version }}
-deploy_archive_src_url: https://github.com/IDR/idr.openmicroscopy.org/releases/download/{{ idr_openmicroscopy_org_version }}/idr.openmicroscopy.org.tar.gz
-# Optional checksum. It should be safe to omit as long as you never
-# overwrite an existing archive. This should not be a problem when using
-# versioned directories.
-deploy_archive_sha256: 29320670b2faf0ad073603e7833de17764bc9ba5db9f57ace39f566346f8c110
-deploy_archive_symlink: /srv/www/html
-idr_deployment_web_version_file: /srv/www/{{ idr_openmicroscopy_org_version }}/VERSION
-idr_deployment_web_version_value: "{{ idr_environment | default('idr') }}"
-
-
 ######################################################################
 # openmicroscopy.fluentd vars
 fluentd_groups:

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -2,15 +2,37 @@
 
 - hosts: "{{ idr_environment | default('idr') }}-proxy-hosts"
 
-  roles:
-  - role: ome.deploy_archive
-    become: yes
-
   tasks:
+  - name: Install Python 3
+    become: true
+    yum:
+      name: python36
+      state: present
+
   - name: Set website displayed version
     become: yes
     copy:
-      content: "{{ idr_deployment_web_version_value }}"
-      dest: "{{ idr_deployment_web_version_file }}"
+      content: "{{ idr_environment | default('idr') }}"
+      dest: /srv/www/VERSION
       force: yes
       mode: 0644
+
+  - name: Install deployment script
+    become: yes
+    template:
+      src: files/deploy
+      dest: /usr/local/bin/deploy
+      mode: 0555
+
+  - name: Install Cron daemon
+    become: yes
+    yum:
+     name: cronie
+     state: installed
+
+  - name: Add cron job updating the website
+    become: yes
+    cron:
+      name: "Deploy the website"
+      special_time: hourly
+      job: "/usr/local/bin/deploy 2>&1 > /dev/null || /usr/local/bin/deploy -f"

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -34,6 +34,12 @@
       dest: /usr/local/bin/deploy
       mode: 0555
 
+  - name: Run deployment script
+    become: yes
+    command: /usr/local/bin/deploy -f
+    args:
+      creates: /srv/www/html
+
   - name: Install Cron daemon
     become: yes
     yum:

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -14,6 +14,9 @@
     file:
       path: /srv/www
       state: directory
+      serole: _default
+      setype: _default
+      seuser: _default
       mode: 0755
 
   - name: Set website displayed version

--- a/ansible/idr-proxy-about.yml
+++ b/ansible/idr-proxy-about.yml
@@ -9,6 +9,13 @@
       name: python36
       state: present
 
+  - name: Create static directory
+    become: yes
+    file:
+      path: /srv/www
+      state: directory
+      mode: 0755
+
   - name: Set website displayed version
     become: yes
     copy:


### PR DESCRIPTION
Similarly to a change that was made for www.openmicroscopy.org, this removes the requirement to track the explicit version of the static website deployed at https://idr.openmicroscopy.org/about/. The ome.deploy_archive job is replaced by a simple Python script which polls hourly for new GitHub releases and deploys them if it finds them.

The environment version is stored as a source of truth under /srv/www/VERSION and copied as part of the deployment script.

This was a long standing improvement in my backlog especially in terms of released but it was primarily motivated by https://github.com/IDR/deployment/commit/36fc6ce570b6e2b7d8b71f19acf1136565159640 as the current workflow for updating the IDR static website requires 1- a tag + release on the source repo 2- the execution of an Ansible playbook and 3- a commit against this repo to update the variables and prevent regression. All of this feels unnecessary complex for changes that could be as simple as updating a typo. 

In terms of workflow, this also means that the only requirement is to push a tag to https://github.com/IDR/idr.openmicroscopy.org and the new release should be automatically deployed within an hour like for https://www.openmicroscopy.org/.
