### PR TITLE
Upgrade PSQL version to 13

### DIFF
--- a/ansible/decommission/archive-instance-services.yml
+++ b/ansible/decommission/archive-instance-services.yml
@@ -18,7 +18,7 @@
     - redis
     - httpd
     - nginx
-    - postgresql-11
+    - postgresql-13
     - prometheus-node-exporter
     - prometheus-omero-py
     - docker

--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -25,7 +25,7 @@ postgresql_users:
 
 postgresql_server_chown_datadir: True
 
-postgresql_version: "11"
+postgresql_version: "13"
 
 
 idr_omero_readonly_database:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -52,7 +52,7 @@ ice_install_python: false
 #idr_ANSIBLE_ENVIRONMENT_VARIABLES: { OMEGO_SSL_NO_VERIFY: 1 }
 
 # This is needed to ensure the client version matches the server
-postgresql_version: "11"
+postgresql_version: "13"
 
 
 ######################################################################

--- a/ansible/molecule/publicidr/tests/test_database.py
+++ b/ansible/molecule/publicidr/tests/test_database.py
@@ -6,7 +6,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_services_running_and_enabled(host):
-    service = host.service('postgresql-11')
+    service = host.service('postgresql-13')
     assert service.is_running
     assert service.is_enabled
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -94,10 +94,10 @@
   version: 2.0.0
 
 - src: ome.postgresql
-  version: 5.0.2
+  version: 5.2.0
 
 - src: ome.postgresql_client
-  version: 0.1.2
+  version: 0.2.0
 
 - src: ome.python3_virtualenv
   version: 0.1.2


### PR DESCRIPTION
## Context

As the current PSQL used in IDR is running into its EOL in 5 months time (https://endoflife.date/postgresql), this investigate the deployment steps to upgrade to a more recent version.
PSQL 13 was chosen mostly within the wider context of upgrading the Linux distribution of IDR in the upcoming months. This version matches the default version shipped with Rocky Linux 9. If we decide to go with a different distribution, it should be easier

## Upgrade

In addition to making the playbook changes, a new PSQL upgrade procedure was tested. Previous upgrades (#238 #227)  have involved the classic `pg_dump/pg_restore` workflow which requires provisioning and/or copying a large dump archive given the size of the IDR database (~600G). Recent versions of PSQL include a [pg_upgrade](https://www.postgresql.org/docs/11/pgupgrade.html) utility with notably with a `--link` option which allows to create hard links on the system and copy in place.

After installing the `postgresql-13` server/client packages on a provisioned IDR pilot, the following steps were executed to upgrade the cluster

```
bash-4.2$ rm -rf /var/lib/pgsql/13/data/
bash-4.2$ /usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data/ --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.UTF-8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

creating directory /var/lib/pgsql/13/data ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting default time zone ... UTC
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

initdb: warning: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    /usr/pgsql-13/bin/pg_ctl -D /var/lib/pgsql/13/data/ -l logfile start

bash-4.2$ time /usr/pgsql-13/bin/pg_upgrade --old-bindir /usr/pgsql-11/bin/ --new-bindir /usr/pgsql-13/bin/ --old-datadir /var/lib/pgsql/11/data/ --new-datadir /var/lib/pgsql/13/data/ --link --check
Performing Consistency Checks
-----------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for system-defined composite types in user tables  ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "sql_identifier" user columns          ok
Checking for presence of required libraries                 ok
Checking database user is the install user                  ok
Checking for prepared transactions                          ok
Checking for new cluster tablespace directories             ok

*Clusters are compatible*

real	0m2.151s
user	0m0.056s
sys	0m0.072s
bash-4.2$ time /usr/pgsql-13/bin/pg_upgrade --old-bindir /usr/pgsql-11/bin/ --new-bindir /usr/pgsql-13/bin/ --old-datadir /var/lib/pgsql/11/data/ --new-datadir /var/lib/pgsql/13/data/ --link
Performing Consistency Checks
-----------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for system-defined composite types in user tables  ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "sql_identifier" user columns          ok
Creating dump of global objects                             ok
Creating dump of database schemas
                                                            ok
Checking for presence of required libraries                 ok
Checking database user is the install user                  ok
Checking for prepared transactions                          ok
Checking for new cluster tablespace directories             ok

If pg_upgrade fails after this point, you must re-initdb the
new cluster before continuing.

Performing Upgrade
------------------
Analyzing all rows in the new cluster                       ok
Freezing all rows in the new cluster                        ok
Deleting files from new pg_xact                             ok
Copying old pg_xact to new server                           ok
Setting oldest XID for new cluster                          ok
Setting next transaction ID and epoch for new cluster       ok
Deleting files from new pg_multixact/offsets                ok
Copying old pg_multixact/offsets to new server              ok
Deleting files from new pg_multixact/members                ok
Copying old pg_multixact/members to new server              ok
Setting next multixact ID and offset for new cluster        ok
Resetting WAL archives                                      ok
Setting frozenxid and minmxid counters in new cluster       ok
Restoring global objects in the new cluster                 ok
Restoring database schemas in the new cluster
                                                            ok
Adding ".old" suffix to old global/pg_control               ok

If you want to start the old cluster, you will need to remove
the ".old" suffix from /var/lib/pgsql/11/data/global/pg_control.old.
Because "link" mode was used, the old cluster cannot be safely
started once the new cluster has been started.

Linking user relation files
                                                            ok
Setting next OID for new cluster                            ok
Sync data directory to disk                                 ok
Creating script to analyze new cluster                      ok
Creating script to delete old cluster                       ok
Checking for extension updates                              ok

Upgrade Complete
----------------
Optimizer statistics are not transferred by pg_upgrade so,
once you start the new server, consider running:
    ./analyze_new_cluster.sh

Running this script will delete the old cluster's data files:
    ./delete_old_cluster.sh

real	6m18.413s
user	0m0.942s
sys	0m11.376s
```

The database and omero services were restarted and are working correctly from a quick testing. Finally, the old cluster was cleaned up using the `delete_old_cluster.sh` utility created by the upgrade tool.

Possibly a candidate for the upcoming `prod116` release