### PR TITLE
Allow to override the Slack channel used for logs/notifications

### DIFF
--- a/ansible/idr-ftp-monitoring.yml
+++ b/ansible/idr-ftp-monitoring.yml
@@ -10,7 +10,7 @@
     prometheus_docker_network: monitoring
 
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
-    prometheus_alertmanager_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
+    prometheus_alertmanager_slack_channel: "{{ idr_notify_slack_channel | default('#idr-notify') }}"
 
     prometheus_targets:
     - groupname: nodes

--- a/ansible/management-fluentd.yml
+++ b/ansible/management-fluentd.yml
@@ -122,7 +122,7 @@
   vars:
     fluentd_shared_key: "{{ idr_secret_fluentd_shared_key | default('fluentd') }}"
     fluentd_slack_token: "{{ idr_secret_management_slack_token | default(None) }}"
-    fluentd_slack_channel: "idr-logs-{{ idr_environment | default('idr') }}"
+    fluentd_slack_channel: "{{ idr_logs_slack_channel | default('idr-logs') }}"
     fluentd_elasticsearch_host: elasticsearch
     fluentd_uid: "1010"
     elasticsearch_docker_image: "docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1"

--- a/ansible/management-prometheus.yml
+++ b/ansible/management-prometheus.yml
@@ -75,7 +75,7 @@
 
     prometheus_alert_repeat_interval: 25m
     prometheus_alertmanager_slack_webhook: "{{ idr_secret_management_slack_webhook }}"
-    prometheus_alertmanager_slack_channel: "#idr-notify-{{ idr_environment | default('idr') }}"
+    prometheus_alertmanager_slack_channel: "{{ idr_notify_slack_channel | default('#idr-notify') }}"
     # The defaults in the prometheus role are (30s 5m 3h)
     # When testing you may want to decrease these to make it easier
     #prometheus_alert_group_wait: 10s

--- a/ansible/management.yml
+++ b/ansible/management.yml
@@ -24,4 +24,4 @@
   roles:
   - role: ome.omero_logmonitor
     omero_logmonitor_slack_token: "{{ idr_secret_omero_logmonitor_slack_token | default(None) }}"
-    omero_logmonitor_slack_channel: idr-logs-{{ idr_environment | default('idr') }}
+    omero_logmonitor_slack_channel: "{{ idr_logs_slack_channel | default('idr-logs') }}"


### PR DESCRIPTION
The current workflow involves the creation (or renaming) of a pair of dedicated Slack channels for each new IDR environment. This adds the logic allowing to control the Slack channels via private variables and use a reduced set.