### PR TITLE
Disable TLS 1.0 & 1.1 and use ffdhe2048 DHE group

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -109,6 +109,11 @@ omero_server_config_set:
   omero.client.icetransports: ssl,tcp,ws
   # Disable all components except Blitz and Tables
   omero.server.nodedescriptors: "master:Blitz-0,Tables-0"
+  # To be removed once omero-certificats is released with
+  # https://github.com/ome/omero-certificates/pull/36
+  omero.glacier2.IceSSL.DH.2048: "ffdhe2048.pem"
+  omero.glacier2.IceSSL.ProtocolVersionMax: "TLS1_2"
+  omero.glacier2.IceSSL.Protocols: "TLS1_2"
 
 omero_server_selfsigned_certificates: True
 

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -56,6 +56,16 @@
   roles:
   - role: ome.omero_server
 
+  # To be removed once omero-certificats is released with
+  # https://github.com/ome/omero-certificates/pull/36
+  tasks:
+    - name: Download ffdhe2048 group
+      become: yes
+      get_url:
+        url: https://ssl-config.mozilla.org/ffdhe2048.txt
+        dest: "/data/OMERO/certs/ffdhe2048.pem"
+        force: yes
+
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
 
 # There are two custom IDR modifications departing from a vanilla OMERO.server:

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -53,18 +53,20 @@
 
 - hosts: "{{ idr_environment | default('idr') }}-omeroreadwrite-hosts"
 
-  roles:
-  - role: ome.omero_server
-
   # To be removed once omero-certificats is released with
   # https://github.com/ome/omero-certificates/pull/36
-  tasks:
+  pre_tasks:
     - name: Download ffdhe2048 group
-      become: yes
+      become: true
       get_url:
         url: https://ssl-config.mozilla.org/ffdhe2048.txt
         dest: "/data/OMERO/certs/ffdhe2048.pem"
+        owner: omero-server
+        group: omero-server
         force: yes
+
+  roles:
+  - role: ome.omero_server
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
 

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -56,6 +56,14 @@
   # To be removed once omero-certificats is released with
   # https://github.com/ome/omero-certificates/pull/36
   pre_tasks:
+    - name: Create certs directory
+      become: true
+      file:
+        path: /data/OMERO/certs
+        owner: omero-server
+        group: omero-server
+        state: directory
+
     - name: Download ffdhe2048 group
       become: true
       get_url:


### PR DESCRIPTION
See https://github.com/ome/omero-certificates/pull/36 for the wider context, this commit manually ports the minimal set of changes for CentOS 7 (disabling TLS 1.0/1.1 and using  the pre-defined DH groups ffdhe2048.

These changes should be reviewed once a new version of `omero-certificates` is released with these changes and TLS 1.3 enabling built-in.