### PR TITLE
Update EBI NFS share playbook to also mount S3 buckets

### DIFF
--- a/ansible/idr-ebi-nfs.yml
+++ b/ansible/idr-ebi-nfs.yml
@@ -17,6 +17,12 @@
       path: /uod/idr
       state: directory
 
+  - name: idr | install fuse
+    become: true
+    yum:
+      name: fuse
+      state: present
+
   - name: Install goofys
     become: true
     get_url:

--- a/ansible/idr-ebi-nfs.yml
+++ b/ansible/idr-ebi-nfs.yml
@@ -27,9 +27,9 @@
   - name: Mount S3 endpoints
     become: true
     mount:
-      fstype: "fuse"
+      fstype: fuse
       opts: "{{ item.opts }}"
       path: "{{ item.path }}"
       src: "{{ item.src }}"
-      state: "mounted"
+      state: present
     loop: "{{ ebi_s3_mounts }}"

--- a/ansible/idr-ebi-nfs.yml
+++ b/ansible/idr-ebi-nfs.yml
@@ -1,4 +1,4 @@
-# Setup Embassy IDR NFS shares
+# Setup Embassy IDR shares
 - hosts: >
     {{ idr_environment | default('idr') }}-ebi-nfs
 
@@ -16,3 +16,20 @@
     file:
       path: /uod/idr
       state: directory
+
+  - name: Install goofys
+    become: true
+    get_url:
+      url: https://github.com/kahing/goofys/releases/latest/download/goofys
+      dest: /usr/bin/goofys
+      mode: 0755
+
+  - name: Mount S3 endpoints
+    become: true
+    mount:
+      fstype: "fuse"
+      opts: "{{ item.opts }}"
+      path: "{{ item.path }}"
+      src: "{{ item.src }}"
+      state: "mounted"
+    loop: "{{ ebi_s3_mounts }}"


### PR DESCRIPTION
- Install [goofys](https://github.com/kahing/goofys) under /usr/local/bin
- Install fuse
- Use Ansible mount command to mount the bucket using `/etc/fstab`
- Take an input dictionary defining the bucket, mount points and options