### PR TITLE
Consume version 0.3.6 of the OMERO Prometheus role

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -156,7 +156,7 @@
   version: 0.2.3
 
 - src: ome.omero_prometheus_exporter
-  version: 0.3.2
+  version: 0.3.6
 
 - src: ome.omero_web_django_prometheus
   version: 0.4.1


### PR DESCRIPTION
OMERO.server deployed using the latest release of omero-certificates no longer supports the deprecated TLS 1.0 and 1.1 protocols. The monitoring agent needs to create an OMERO.py client able to negotiate a connection with TLS 1.2. The latest version of the role uncaps the version of OMERO.py installed in the virtual environment which was previously set to 5.6.0.