### PR TITLE
Bump prometheus_exporter version

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -156,7 +156,7 @@
   version: 0.2.3
 
 - src: ome.omero_prometheus_exporter
-  version: 0.3.6
+  version: 0.4.0
 
 - src: ome.omero_web_django_prometheus
   version: 0.4.1


### PR DESCRIPTION
Bump omero_prometheus_exporter version to latest 0.4.0.

Otherwise you run into this issue on Rocky9:
```
TASK [ome.omero_prometheus_exporter : omero prometheus exporter | install python3] ****************************************************************************************
fatal: [68090143-9473-4169-8a4e-86888b22a4f3]: FAILED! => {"changed": false, "failures": ["No package python36 available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```
