### PR TITLE
Set value for effective cache size and use PR #41 for ome.postgresql

### DIFF
--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -38,3 +38,4 @@ postgresql_install_extensions: True
 
 postgresql_server_conf:
   shared_buffers: "{{ (ansible_memtotal_mb / 4) | int }}MB"
+  effective_cache_size: "{{ (ansible_memtotal_mb * 0.75 ) | int }}MB"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -90,8 +90,9 @@
 - name: ome.openstack_volume_storage
   version: 2.0.0
 
-- src: ome.postgresql
-  version: 5.4.0
+- name: ome.postgresql
+  src: https://github.com/khaledk2/ansible-role-postgresql
+  version: using_the_orginal_postgres_config_file
 
 - name: ome.postgresql_client
   version: 0.4.3


### PR DESCRIPTION
This PR sets a value for the effective_cache_size  attribute (75% of the physical machine memory ) and uses https://github.com/ome/ansible-role-postgresql/pull/41 