### PR TITLE
Bump zarr reader 0.5.1

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,9 +6,7 @@
 ######################################################################
 # Shared variables
 
-# Force a downgrade from 5.6.1
-# https://github.com/ome/omero-server/issues/93
-idr_omero_server_release: 5.6.0
+idr_omero_server_release: 5.6.9
 omero_server_checkupgrade_comparator: '!='
 
 idr_omero_web_release: 5.25.0
@@ -21,30 +19,6 @@ idr_omero_web_release: 5.25.0
 # _omero_py_version: ==5.9.0
 
 artifactory_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven"
-
-# Override the lib/client JARs on the omeroreadwrite server
-# Works around the OMERO.server 5.6.3 upgrade issue - to be reverted when
-# the server is upgraded
-# See https://github.com/IDR/deployment/issues/327
-omero_client_jars:
-  - name: omero-romio
-    group: org/openmicroscopy
-    version: "5.6.2"
-  - name: omero-blitz
-    group: org/openmicroscopy
-    version: "5.5.8"
-
-# The IDR OMERO server uses a custom IDR build
-idr_bf_jars:
-  - name: formats-api
-    group: idr
-    version: "0.6.10"
-  - name: formats-bsd
-    group: idr
-    version: "0.6.10"
-  - name: formats-gpl
-    group: idr
-    version: "0.6.10"
 
 ice_install_devel: false
 ice_install_python: false

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -19,10 +19,9 @@ idr_omero_web_release: 5.25.0
 # _omero_py_version: ==5.9.0
 
 artifactory_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven"
-maven_central_baseurl: "https://repo1.maven.org/maven2"
 
 # list from https://github.com/IDR/deployment/pull/420#issuecomment-2173437956
-omero_client_jars:
+zarrreader_jars:
   - name: aws-java-sdk-s3
     group: com/amazonaws
     version: "1.12.659"
@@ -47,6 +46,9 @@ omero_client_jars:
   - name: jackson-dataformat-cbor
     group: com/fasterxml/jackson/dataformat
     version: "2.12.6"
+  - name: OMEZarrReader
+    group: ome
+    version: "0.5.1"
 
 ice_install_devel: false
 ice_install_python: false

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -19,6 +19,34 @@ idr_omero_web_release: 5.25.0
 # _omero_py_version: ==5.9.0
 
 artifactory_baseurl: "https://artifacts.openmicroscopy.org/artifactory/maven"
+maven_central_baseurl: "https://repo1.maven.org/maven2"
+
+# list from https://github.com/IDR/deployment/pull/420#issuecomment-2173437956
+omero_client_jars:
+  - name: aws-java-sdk-s3
+    group: com/amazonaws
+    version: "1.12.659"
+  - name: aws-java-sdk-kms
+    group: com/amazonaws
+    version: "1.12.659"
+  - name: jmespath-java
+    group: com/amazonaws
+    version: "1.12.659"
+  - name: aws-java-sdk-core
+    group: com/amazonaws
+    version: "1.12.659"
+  - name: commons-codec
+    group: commons-codec
+    version: "1.15"
+  - name: httpclient
+    group: org/apache/httpcomponents
+    version: "4.5.13"
+  - name: httpcore
+    group: org/apache/httpcomponents
+    version: "4.4.13"
+  - name: jackson-dataformat-cbor
+    group: com/fasterxml/jackson/dataformat
+    version: "2.12.6"
 
 ice_install_devel: false
 ice_install_python: false

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -6,7 +6,7 @@
 ######################################################################
 # Shared variables
 
-idr_omero_server_release: 5.6.9
+idr_omero_server_release: 5.6.11
 omero_server_checkupgrade_comparator: '!='
 
 idr_omero_web_release: 5.25.0

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -208,19 +208,17 @@
     - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/OMEZarrReader.jar"
         force: yes
-      with_items: "{{ idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/OMEZarrReader.jar"
         force: yes
-      with_items: "{{ omero_client_jars + idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -208,17 +208,19 @@
     - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/OMEZarrReader.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
         force: yes
+      with_items: "{{ zarrreader_jars }}"
       notify: restart omero-server
 
     - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/OMEZarrReader.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
         force: yes
+      with_items: "{{ zarrreader_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -78,7 +78,7 @@
     - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.5.1/OMEZarrReader-0.5.1.jar"
         dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/OMEZarrReader.jar"
         force: yes
       notify: restart omero-server
@@ -86,7 +86,7 @@
     - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.5.1/OMEZarrReader-0.5.1.jar"
         dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/OMEZarrReader.jar"
         force: yes
       notify: restart omero-server

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -78,17 +78,19 @@
     - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.5.1/OMEZarrReader-0.5.1.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/OMEZarrReader.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
         force: yes
+      with_items: "{{ zarrreader_jars }}"
       notify: restart omero-server
 
     - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.5.1/OMEZarrReader-0.5.1.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/OMEZarrReader.jar"
+        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
         force: yes
+      with_items: "{{ zarrreader_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/idr-omero.yml
+++ b/ansible/idr-omero.yml
@@ -78,19 +78,17 @@
     - name: Override lib/server JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/{{ item.name }}.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/server/OMEZarrReader.jar"
         force: yes
-      with_items: "{{ idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Override lib/client JARs
       become: yes
       get_url:
-        url: "{{ artifactory_baseurl }}/{{ item.group }}/{{ item.name }}/{{ item.version }}/{{ item.name }}-{{ item.version }}.jar"
-        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/{{ item.name }}.jar"
+        url: "{{ artifactory_baseurl }}/ome/OMEZarrReader/0.4.0/OMEZarrReader-0.4.0.jar"
+        dest: "{{ omero_common_basedir }}/server/OMERO.server/lib/client/OMEZarrReader.jar"
         force: yes
-      with_items: "{{ omero_client_jars + idr_bf_jars }}"
       notify: restart omero-server
 
     - name: Remove OMERO scripts

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -79,7 +79,7 @@
   version: 3.1.0
 
 - src: ome.omero_server
-  version: 6.0.0
+  version: 6.1.0
 
 - name: ome.omero_user
   version: 0.4.0


### PR DESCRIPTION
NB: this is on top of @dominikl's PR: https://github.com/IDR/deployment/pull/420/ following the discussion there, particularly https://github.com/IDR/deployment/pull/420#issuecomment-2178112947

@sbesson: I have added the list of jars under `omero_client_jars` but as I understand it, this will attempt to load those jars from the OME artifactory, not from maven central?

I added a variable `maven_central_baseurl: "https://repo1.maven.org/maven2"` and I should probably list the jars under a different variable like `omero_client_maven_jars` but I don't know where to update the logic that would consume that list.

cc @dominikl @jburel 