### PR TITLE
PostgreSQL: set effective_cache_size and increase max_connections

### DIFF
--- a/ansible/group_vars/database-hosts.yml
+++ b/ansible/group_vars/database-hosts.yml
@@ -38,3 +38,5 @@ postgresql_install_extensions: True
 
 postgresql_server_conf:
   shared_buffers: "{{ (ansible_memtotal_mb / 4) | int }}MB"
+  effective_cache_size: "{{ (ansible_memtotal_mb * 0.75 ) | int }}MB"
+  max_connections: 150


### PR DESCRIPTION
The first configuration change was found to be the critical parameter modified during the Rocky Linux 9 migration. The maximal number of connections was bumped during the work on test122

For the next release, we might want to resurrect the work on #424 but the underlying Ansible changes requires additional assessment. In the scope of the `prod122` release, this should contain the minimal set of PostgreSQL variable changes to allow deployments without manually copying a configuration file over.