### PR TITLE
Add antibody name to mapr search

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -425,6 +425,7 @@ omero_web_apps_config_set:
       default:
         - "Antibody Identifier"
       all:
+        - "Antibody Name"
         - "Antibody Identifier"
       ns:
         - "openmicroscopy.org/mapr/antibody"


### PR DESCRIPTION
See title. For testing this probably has to be applied to pilot-idr0159, because the field "Antibody Name" doesn't exist in other deployments (renamed from "Antibody").
/cc @sbesson 