### PR TITLE
Update Nginx Configuration to use Microservice  after updating OMERO-Web

### DIFF
--- a/ansible/idr-omero-web.yml
+++ b/ansible/idr-omero-web.yml
@@ -10,3 +10,23 @@
   # Vars are in group_vars/omero-hosts.yml
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"
+
+# This bloock will run in case of updating omero-web
+# It will check for the ms user exists
+# If so, it will run the role to update the omero web nginx configuration file
+
+- hosts: "{{ idr_environment | default('idr') }}-omeroreadonly-hosts"
+  become: true
+
+  pre_tasks:
+  - name: check if ms user exist
+    ansible.builtin.user:
+      name: "omero-server"
+    check_mode: true
+    register: service_user
+
+  roles:
+  - role: ome.omero_ms_image_region
+    when: "{{ service_user.state | d('') == 'present' }}"
+
+  environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -39,8 +39,9 @@
 - name: ome.ice
   version: 4.4.4
 
-- src: ome.iptables_raw
-  version: 0.4.0
+- name: ome.iptables_raw
+  src: https://github.com/khaledk2/ansible-role-iptables-raw
+  version: upgrade_package_name
 
 - src: ome.java
   version: 2.2.0


### PR DESCRIPTION
This PR fixes the issue https://github.com/IDR/deployment/issues/436 .
I have added a check on the `idr-omero-web` playbook for Micros-services user existence, i.e., `omero-server.` If so, it runs the `omero_ms_image_region` role to update the Nginx configuration file for MS.
The MS deployment cannot be moved to this playbook as the MS user is created after running this playbook.

The molecule test failed without modification due to the failure of starting `iptables `service
https://github.com/khaledk2/deployment/actions/runs/11316428331/job/31468697284#step:5:1497
I have checked this issue and found out that it failed due to this error:
`/sbin/iptables does not exist`
I have checked the `iptables_raw `role and successfully ran the molecule test. I compared the installation packages on the role molecule test and the installation package on the deployment playbook, and they are not identical; more packages are installed on the role which are related to `iptables-nft.` 
I have changed the installation package on the iptables_raw from `iptables-services` to `iptables-nft-services` and updated the deployment requirements to point to this modified branch (https://github.com/khaledk2/ansible-role-iptables-raw/tree/refs/heads/upgrade_package_name).
Then I ran the molecule tests in the deployment repo and it passed.
I will open PR for the `iptables_raw` role  shortly 
