### PR TITLE
Mapr deprecation

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -245,10 +245,10 @@ omero_web_apps_packages:
 - idr-gallery==3.11.0
 - omero-figure==6.2.0
 omero_web_apps_names:
-- omero_mapr
 - omero_iviewer
 - idr_gallery
 - omero_figure
+- omero_mapr
 
 omero_web_apps_top_links:
 - label: Studies

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -241,7 +241,7 @@ omero_web_config_set:
 
 omero_web_apps_packages:
 - omero-mapr==0.5.2
-- omero-iviewer==0.14.0
+- omero-iviewer==0.15.0
 - idr-gallery==3.12.0
 - omero-figure==6.2.0
 omero_web_apps_names:

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -243,7 +243,7 @@ omero_web_apps_packages:
 - omero-mapr==0.5.3
 - omero-iviewer==0.15.0
 - idr-gallery==3.12.1
-- omero-figure==6.2.0
+- omero-figure==7.1.0
 omero_web_apps_names:
 - omero_iviewer
 - idr_gallery

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -242,7 +242,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.5.2
 - omero-iviewer==0.15.0
-- idr-gallery==3.12.0
+- idr-gallery==3.12.1
 - omero-figure==6.2.0
 omero_web_apps_names:
 - omero_iviewer

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -242,7 +242,7 @@ omero_web_config_set:
 omero_web_apps_packages:
 - omero-mapr==0.5.2
 - omero-iviewer==0.14.0
-- idr-gallery==3.11.0
+- idr-gallery==3.12.0
 - omero-figure==6.2.0
 omero_web_apps_names:
 - omero_iviewer

--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -240,7 +240,7 @@ omero_web_config_set:
 # Plugins and additional web configuration
 
 omero_web_apps_packages:
-- omero-mapr==0.5.2
+- omero-mapr==0.5.3
 - omero-iviewer==0.15.0
 - idr-gallery==3.12.1
 - omero-figure==6.2.0

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -64,12 +64,6 @@ _nginx_proxy_backends_omero:
   cache_validity: 1d
   maintenance_flag: "{{ omero_maintenance_flag }}"
   maintenance_uri: "{{ omero_maintenance_uri }}"
-- name: omeromapr
-  location: ~ /mapr/*
-  server: http://omeroreadonly
-  cache_validity: 180d
-  maintenance_flag: "{{ omero_maintenance_flag }}"
-  maintenance_uri: "{{ omero_maintenance_uri }}"
 - name: omerostatic
   location: ~ /static/*
   server: http://omeroreadonly

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -250,7 +250,7 @@ nginx_proxy_redirect_map_locations:
   code: 302
 
 - location: "~ ^/mapr/api/(?!config).*($|/)"
-  code: 410
+  redirect302: /searchengine/apidocs/
 
 # "= /" has higher priority than "/" in the proxy config
 nginx_proxy_direct_locations:

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -249,9 +249,6 @@ nginx_proxy_redirect_map_locations:
 - location: "~ ^/(mito|tara|pgpc|study)($|/)"
   code: 302
 
-- location: "~ ^/mapr/api/(?!config).*($|/)"
-  redirect302: /searchengine/apidocs/
-
 # "= /" has higher priority than "/" in the proxy config
 nginx_proxy_direct_locations:
 # TODO: change to 301 when we're happy
@@ -274,6 +271,8 @@ nginx_proxy_direct_locations:
   alias: /srv/www/letsencrypt/challenge
 - location: "= /submitter-survey"
   redirect302: https://forms.gle/beR4vqLrgLgRzgSX9
+- location: "~ ^/mapr/api/(?!config).*($|/)"
+  redirect302: /searchengine/apidocs/
 
 
 # CORS: basically allow any cross-site since this is public read-only

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -249,7 +249,7 @@ nginx_proxy_redirect_map_locations:
 - location: "~ ^/(mito|tara|pgpc|study)($|/)"
   code: 302
 
-- location: "~ ^/mapr/api/(antibody|gene|compound|sirna|omap|phenotype|organism|orf|cellline|protein)($|/)"
+- location: "~ ^/mapr/api/(?!config).*($|/)"
   code: 410
 
 # "= /" has higher priority than "/" in the proxy config

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -145,7 +145,7 @@ nginx_proxy_cache_match_uri:
 - '"~web(client|gateway)/get_thumbnail*"'
 - '"~(webclient/)?api/*"'
 - '"~static/*"'
-- '"~mapr/*"'
+# - '"~mapr/*"'
 - '"~gallery-api/*"'
 - '"~webclient/img_detail/*"'
 - '"~iviewer/*"'
@@ -192,12 +192,6 @@ nginx_proxy_caches:
   inactive: 180d
   match:
   - '"~(webclient/)?api/*"'
-- name: omeromapr
-  maxsize: 5g
-  keysize: 100m
-  inactive: 180d
-  match:
-  - '"~mapr/*"'
 - name: omeroviewers  # Metadata for viewers and related UI
   maxsize: 1g
   keysize: 1m

--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -249,6 +249,9 @@ nginx_proxy_redirect_map_locations:
 - location: "~ ^/(mito|tara|pgpc|study)($|/)"
   code: 302
 
+- location: "~ ^/mapr/api/(antibody|gene|compound|sirna|omap|phenotype|organism|orf|cellline|protein)($|/)"
+  code: 410
+
 # "= /" has higher priority than "/" in the proxy config
 nginx_proxy_direct_locations:
 # TODO: change to 301 when we're happy

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -40,7 +40,7 @@
   version: 4.4.4
 
 - src: ome.iptables_raw
-  version: 0.4.0
+  version: 0.4.1
 
 - src: ome.java
   version: 2.2.0


### PR DESCRIPTION
This represents the changes I have been making manually on idr-testing with the replacement of mapr searches with searchengine, described at https://github.com/IDR/idr-gallery/pull/45

Summary of changes:

 - Move mapr app *AFTER* idr-gallery so that URLs such as `/mapr/gene/` get handled by idr-gallery instead of mapr
 - Remove the mapr cache so that we don't get the cached response for these URLs
 - For `/mapr/api/[key]/` requests we now response with a 410 response. [EDIT] Now redirects to /searchengine/apidocs/ 302 response - see below.
 - Bumps idr-gallery to 3.12.0 to include the 'mapr-redirect' PR above and https://github.com/IDR/idr-gallery/pull/47.

NB: I couldn't see where to add the file I created with:

```sudo vi /usr/share/nginx/html/410.html``` (based on the 50x.html)

```
<!DOCTYPE html>
<html>
<head>
<title>Error</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<p>mapr/api pages have been removed.</p>
<p>
  Please use searchengine instead. See
  <a href="https://idr.openmicroscopy.org/searchengine/apidocs/">https://idr.openmicroscopy.org/searchengine/apidocs/</a>
</p>
</body>
</html>
```

Also the config for this file looks like:
```
    error_page 410 /410.html;
    location = /410.html {
        root   /usr/share/nginx/html;
    }
```
In my testing, I had added this in `proxy-default.conf` right before the `location` entry that I have added above:
```
    location ~ ^/mapr/api/(antibody|gene|compound|sirna|omap|phenotype|organism|orf|cellline|protein)($|/) {
        return 410;
    }
```

The `error_page 410` about follows on from `error_page 50x` etc section in the same file, but I don't see that this is specified anywhere in this repo, so maybe that comes from existing nginx config somewhere?