### PR TITLE
Bump ome.nginx_proxy to 1.16.2 - ssl changes

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -70,7 +70,7 @@
   version: 2.2.1
 
 - src: ome.nginx_proxy
-  version: 1.16.1
+  version: 1.16.2
 
 - src: ome.omero_common
   version: 0.4.0


### PR DESCRIPTION
As discussed, bumping the role after release.

cc @sbesson @dominikl 