### PR TITLE
Bump cli render and metadata versions

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -87,8 +87,8 @@ omero_server_datadir_bioformatscache: /data/BioFormatsCache
 omero_server_systemd_limit_nofile: 16384
 
 omero_server_python_addons:
-- omero-cli-render==0.8.0
-- omero-metadata==0.12.0
+- omero-cli-render==0.8.1
+- omero-metadata==0.13.0
 - omero-upload==0.4.0
 - omero-rois==0.3.0
 


### PR DESCRIPTION
Just noticed that we don't use the latest render and metadata versions.