### PR TITLE
Only redirect specific /study/idr0083/figure urls. Ignore other /stud…

### DIFF
--- a/ansible/group_vars/proxy-hosts.yml
+++ b/ansible/group_vars/proxy-hosts.yml
@@ -239,8 +239,13 @@ nginx_proxy_redirect_map:
   dest: /webclient/img_detail/9822152/?dataset=10201&x=80560&y=77440&zm=66&c=1|495:9204$808080&m=g
 
 nginx_proxy_redirect_map_locations:
+# These are the only /study/ URLs that should be redirected
+- location: "= /study/idr0083/figure/4i"
+  code: 301
+- location: "= /study/idr0083/figure/4r"
+  code: 301
 # TODO: change to 301 when we're happy
-- location: "~ ^/(mito|tara|pgpc|study)($|/)"
+- location: "~ ^/(mito|tara|pgpc)($|/)"
   code: 302
 
 # "= /" has higher priority than "/" in the proxy config


### PR DESCRIPTION

This aims to address issues found at https://github.com/IDR/idr-gallery/pull/50 where we want to create new landing pages for every study at e.g. `idr.openmicroscopy.org/study/idr0001/`.

This currently fails because all `/study/` URLs are redirected because we want to support https://idr.openmicroscopy.org/study/idr0083/figure/4i and https://idr.openmicroscopy.org/study/idr0083/figure/4r redirects.

This PR attempts to be more specific, ONLY handling those 2 urls and not redirecting other `/study` urls.

I don't have an easy way to test this. This was created with the help of ChatGPT!

cc @sbesson 