### PR TITLE
Change the Elasticsearch backup folder ownership

### DIFF
--- a/ansible/idr-elasticsearch.yml
+++ b/ansible/idr-elasticsearch.yml
@@ -15,6 +15,7 @@
       path: "{{ elasticsearch_backup_folder }}"
       owner: 1000
       group: root
+      recurse: yes
       state: directory
 
   - name: Create app top level directory


### PR DESCRIPTION
This PR changes the ownership of the Elasticsearch backup folder to resolve the access permission issue I encountered while attempting to create the backup.
