### PR TITLE
Add ome-zarr-py to omero_server_python_addons

### DIFF
--- a/ansible/group_vars/omero-hosts.yml
+++ b/ansible/group_vars/omero-hosts.yml
@@ -112,6 +112,7 @@ omero_server_python_addons:
 - omero-metadata==0.13.0
 - omero-upload==0.4.0
 - omero-rois==0.3.0
+- ome-zarr-py==0.11.0
 
 omero_server_config_set:
   omero.db.poolsize: 25


### PR DESCRIPTION
This is a proposal of one possible solution to a problem, or the start of a discussion... (I hope I've made the change in the correct place?)

Currently I have been running `register.py` https://github.com/BioNGFF/omero-import-utils/blob/main/metadata/register.py
on the pilot-idr9999 in the `/opt/omero/server/venv/` environment and now that this script has zarr & dask as a dependency in https://github.com/BioNGFF/omero-import-utils/pull/7 it's handy to have an environment with those packages.

Also, it has been VERY useful to have `ome-zarr-py` installed in an environment on the server because we have OME-Zarr data there which we want to inspect via the ngff-validator, so we want to serve the data with CORS headers enabled, which is handled by the `$ ome_zarr view /data/testing/...zarr` command, with port forwarding to port 8000.

Vanilla python http server with CORS requires a bit more code: e.g. https://gist.github.com/amriunix/00c4209ba7ecf384e925fc99d98658c5

cc @dominikl 