### PR TITLE
Update Elasticsearch server version

### DIFF
--- a/ansible/group_vars/searchengine-hosts.yml
+++ b/ansible/group_vars/searchengine-hosts.yml
@@ -6,7 +6,7 @@ default_datasource: idr
 database_username: omeroreadonly
 database_user_password: "{{ idr_secret_postgresql_password_ro | default('omero') }}"
 searchenginecache_folder: /data/searchengine/searchengine/cacheddata/
-search_engineelasticsearch_docker_image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
+search_engineelasticsearch_docker_image: docker.elastic.co/elasticsearch/elasticsearch:9.1.3
 searchengine_docker_image: openmicroscopy/omero-searchengine:0.7
 # ansible_python_interpreter: path/to/bin/python
 searchengine_index: searchengine_index


### PR DESCRIPTION
This PR updates the Elasticsearch version to ensure compatibility with the searchengine after its dependency packages were upgraded (https://github.com/ome/omero_search_engine/pull/115). The Searchengine version will be updated as soon as the new release becomes available. 