### PR TITLE
Deploy the search engien with Nginx and Gunicorn

### DIFF
--- a/ansible/idr-02-services.yml
+++ b/ansible/idr-02-services.yml
@@ -9,6 +9,6 @@
 ## Search services
 - import_playbook: idr-elasticsearch.yml
 - import_playbook: idr-searchengine.yml
-
+- import_playbook: idr-searchengine_nginx.yml
 ## Restore searchengine data if existence
 - import_playbook: restore_searchengine_data.yml

--- a/ansible/idr-searchengine_nginx.yml
+++ b/ansible/idr-searchengine_nginx.yml
@@ -1,0 +1,19 @@
+- name: Deploying nginx for search engine
+  hosts: "{{ idr_environment | default('idr') }}-searchengine-hosts"
+
+  tasks:
+  - name: Include ome.nginx role
+    ansible.builtin.include_role:
+      name: ome.nginx
+
+  - name:  write nginx config
+    become: true
+    ansible.builtin.template:
+      dest: /etc/nginx/conf.d/searchengine.conf
+      src: searchengine.conf.j2
+      mode: 0644
+
+  - name: Restart nginx
+    service:
+      name: nginx
+      state: restarted

--- a/ansible/templates/searchengine.conf.j2
+++ b/ansible/templates/searchengine.conf.j2
@@ -1,0 +1,16 @@
+
+server {
+    listen 8080;
+
+     location /searchengine {
+
+        proxy_pass http://127.0.0.1:5577/searchengine;
+        proxy_redirect http://127.0.0.1:5577/searchengine $scheme://$server_name;
+        proxy_set_header Host $host/searchengine;
+    }
+
+    location /send_file/ {
+    internal;
+    alias /{{ apps_folder }}/data_dump/;   # real file storage
+}
+}


### PR DESCRIPTION
This PR modifies the searchengine deployment to work with Nginx. This is primarily intended to facilitate work on the searchengine, `Dump data and Query results in bff format` PR (https://github.com/ome/omero_search_engine/pull/114#issuecomment-3225686937)