### PR TITLE
revert back to 2024.08.13 version

### DIFF
--- a/ansible/idr-omero-readonly.yml
+++ b/ansible/idr-omero-readonly.yml
@@ -256,7 +256,7 @@
 
   roles:
   - role: ome.omero_ms_image_region
-    omero_ms_image_region_download_URL: 'https://github.com/ome/omero-ms-image-region/releases/download/v2025.11.05/omero-ms-image-region-0.10.0_21.zip'
-    omero_ms_image_region_package_sha256: 128c1d27059c748a828908d60619814ace65376bc3040b5d8146154579a13003
+    omero_ms_image_region_download_URL: 'https://github.com/ome/omero-ms-image-region/releases/download/2024.08.13/omero-ms-image-region-0.10.0_11.zip'
+    omero_ms_image_region_package_sha256: f45fb83cf55b4c87bb15b58a5c314ebd355d59cab9225d1bb598130d32fb86d9
 
   environment: "{{ idr_ANSIBLE_ENVIRONMENT_VARIABLES | default({}) }}"


### PR DESCRIPTION
Revert ms back to 2024.08.13, because v2025.11.05 includes newer bioformats. Also use java 11 build.

